### PR TITLE
Possible fix for issue 24

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,7 +103,7 @@ async function validateJava() {
     
     return new Promise((resolve, reject) => {
         cp.exec(`"${exePath}" -version`, (e, stdout, stderr) => {
-            let regexp:RegExp = /java version "((\d+)(\.(\d+).+?)?)"/g;
+            let regexp:RegExp = /(?:java|openjdk) version "((\d+)(\.(\d+).+?)?)"/g;
             if (stderr) {
                 let match = regexp.exec(stderr);
                 if (match) {


### PR DESCRIPTION
Updated regexp in validateJava to also parse openjdk version. Works fine for me.