### PR TITLE
支持替换环境变量

### DIFF
--- a/src/debugger/EmmyDebugSession.ts
+++ b/src/debugger/EmmyDebugSession.ts
@@ -307,8 +307,14 @@ export class EmmyDebugSession extends DebugSession implements IEmmyStackContext 
                 bpsResp.push(bpResp);
             }
             response.body = { breakpoints: bpsResp };
+
+            for(let idx = this.breakpoints.length - 1; idx >= 0; idx--) {
+                if(this.breakpoints[idx].file === path) {
+                    this.breakpoints.splice(idx, 1);
+                }
+            }
+            this.breakpoints = this.breakpoints.concat(bpsProto);
         }
-        this.breakpoints = bpsProto;
         this.sendBreakpoints();
         this.sendResponse(response);
     }

--- a/src/findJava.ts
+++ b/src/findJava.ts
@@ -14,7 +14,8 @@ export default function(): string|null {
     
     var settingsPath = vscode.workspace.getConfiguration("emmylua").get("java.home");
     if (settingsPath) {
-        let javaPath = path.join(<string>settingsPath, "bin", executableFile);
+		let fullPath = (<string>settingsPath).replace(/(\$\{workspaceFolder\})/gmi, vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : "");
+        let javaPath = path.join(fullPath, "bin", executableFile);
         return javaPath;
     }
 


### PR DESCRIPTION
团队里共享 java 目录时，可以通过目录的相对路径。（否则无法定位当前目录)