### PR TITLE
fix oly one file is breakable

### DIFF
--- a/src/debugger/EmmyDebugSession.ts
+++ b/src/debugger/EmmyDebugSession.ts
@@ -302,11 +302,18 @@ export class EmmyDebugSession extends DebugSession implements IEmmyStackContext 
                 bpsResp.push(bpResp);
             }
             response.body = { breakpoints: bpsResp };
+
+            for(let idx = this.breakpoints.length - 1; idx >= 0; idx--) {
+                if(this.breakpoints[idx].file === path) {
+                    this.breakpoints.splice(idx, 1);
+                }
+            }
+            this.breakpoints = this.breakpoints.concat(bpsProto);
         }
-        this.breakpoints = bpsProto;
         this.sendBreakpoints();
         this.sendResponse(response);
     }
+
 
     private sendBreakpoints() {
         const req: proto.IAddBreakPointReq = {

--- a/src/debugger/EmmyDebugSession.ts
+++ b/src/debugger/EmmyDebugSession.ts
@@ -303,11 +303,7 @@ export class EmmyDebugSession extends DebugSession implements IEmmyStackContext 
             }
             response.body = { breakpoints: bpsResp };
 
-            for(let idx = this.breakpoints.length - 1; idx >= 0; idx--) {
-                if(this.breakpoints[idx].file === path) {
-                    this.breakpoints.splice(idx, 1);
-                }
-            }
+            this.breakpoints = this.breakpoints.filter(v => v.file !== path);
             this.breakpoints = this.breakpoints.concat(bpsProto);
         }
         this.sendBreakpoints();


### PR DESCRIPTION
现像:
       VSCode 作为 Listener 的情况下，只有一个文件的 breakpoint 起作用
  
原因:
       VSCode 一个文件如果 bp 发生改动，只触发一次，所以 proto.IAddBreakPointReq 协议会把 clear 设置为 true, 然后把这**一个**文件的所有 bp 发给 EmmyLuaDebugger
       但是 EmmyLuaDebugger 库中的 [EmmyFacade::OnAddBreakPointReq](https://github.com/EmmyLua/EmmyLuaDebugger/blob/929da5262d76181d5e4d54501113f16067ee062b/emmy_core/emmy_facade.cpp#L299) 中，如果 clear 为 true, 会清除所有断点  
  
解决:
       VSCode 如果发生 bp 改动，记录所有 当前的断点。当断点信息发生改变时，把所有断点发送给 EmmyLuaDebugger.
       缺点是如果 bp 比较多，会有浪费。优点是改动比较小，不用改协议，符合现有设计。
  