### PR TITLE
add feature substitute workspaceFolder

### DIFF
--- a/src/debugger/EmmyDebugSession.ts
+++ b/src/debugger/EmmyDebugSession.ts
@@ -302,11 +302,14 @@ export class EmmyDebugSession extends DebugSession implements IEmmyStackContext 
                 bpsResp.push(bpResp);
             }
             response.body = { breakpoints: bpsResp };
+
+            this.breakpoints = this.breakpoints.filter(v => v.file !== path);
+            this.breakpoints = this.breakpoints.concat(bpsProto);
         }
-        this.breakpoints = bpsProto;
         this.sendBreakpoints();
         this.sendResponse(response);
     }
+
 
     private sendBreakpoints() {
         const req: proto.IAddBreakPointReq = {

--- a/src/debugger/EmmyDebugSession.ts
+++ b/src/debugger/EmmyDebugSession.ts
@@ -46,11 +46,6 @@ export class EmmyDebugSession extends DebugSession implements IEmmyStackContext 
             this.listenMode = true;
             const socket = net.createServer(client => {
                 this.client = client;
-                readline.createInterface({
-                    input: <NodeJS.ReadableStream> client,
-                    output: client
-                })
-                .on("line", line => this.onReceiveLine(line));
                 this.sendResponse(response);
                 this.onConnect(this.client);
                 this.readClient(client);

--- a/src/findJava.ts
+++ b/src/findJava.ts
@@ -14,7 +14,10 @@ export default function(): string|null {
     
     var settingsPath = vscode.workspace.getConfiguration("emmylua").get("java.home");
     if (settingsPath) {
-        let javaPath = path.join(<string>settingsPath, "bin", executableFile);
+        let fullPath = (<string>settingsPath).replace(
+            /(\$\{workspaceFolder\})/gmi, 
+            vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : "");
+      	let javaPath = path.join(fullPath, "bin", executableFile);
         return javaPath;
     }
 

--- a/src/findJava.ts
+++ b/src/findJava.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as vscode from "vscode";
+import {substituteFolder} from "./substitution";
 
 function validateJava(javaPath: string): boolean {
 	//TODO check java path
@@ -14,9 +15,7 @@ export default function(): string|null {
     
     var settingsPath = vscode.workspace.getConfiguration("emmylua").get("java.home");
     if (settingsPath) {
-        let fullPath = (<string>settingsPath).replace(
-            /(\$\{workspaceFolder\})/gmi, 
-            vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : "");
+		let fullPath = substituteFolder(<string>settingsPath);
       	let javaPath = path.join(fullPath, "bin", executableFile);
         return javaPath;
     }

--- a/src/findJava.ts
+++ b/src/findJava.ts
@@ -15,8 +15,8 @@ export default function(): string|null {
     
     var settingsPath = vscode.workspace.getConfiguration("emmylua").get("java.home");
     if (settingsPath) {
-		let fullPath = substituteFolder(<string>settingsPath);
-      	let javaPath = path.join(fullPath, "bin", executableFile);
+        let fullPath = substituteFolder(<string>settingsPath);
+        let javaPath = path.join(fullPath, "bin", executableFile);
         return javaPath;
     }
 

--- a/src/substitution.ts
+++ b/src/substitution.ts
@@ -1,0 +1,30 @@
+import * as path from "path";
+import {workspace} from "vscode";
+
+function getWorkspaceFolderByName(workspaceName?: string): string | null {
+    const ws = workspace.workspaceFolders;
+    if(ws)
+    {
+        let workspace = ws.find(w => w.name === workspaceName);
+        if(workspace) {
+            return workspace.uri.fsPath;
+        } else {
+            return ws[0].uri.fsPath;
+        }
+    }
+    return null;
+}
+
+export function substituteFolder(oriPath: string): string {
+    let ret = oriPath;
+    let pattern = /(?:\$\{workspaceFolder(?:\:([^\.]+))?\})/;
+    let innerMatch = pattern.exec(oriPath);
+    if(innerMatch !== null) {
+        let path = getWorkspaceFolderByName(innerMatch[1]);
+        if(path) {
+            ret = oriPath.replace(pattern, path);
+        }
+    }
+    ret = path.resolve(ret);
+    return ret;
+}


### PR DESCRIPTION
设置 java path 里可以根据 workspaceFolder 指定相对路径。
这样可以在团队里共享 java 设置（java 在版本库里）
vsc 默认不会替代。

貌似 MS 暂时是没计划支持了。
https://github.com/microsoft/vscode/issues/46471