### PR TITLE
fix duplicated parser on listen mode

### DIFF
--- a/src/debugger/EmmyDebugSession.ts
+++ b/src/debugger/EmmyDebugSession.ts
@@ -46,11 +46,6 @@ export class EmmyDebugSession extends DebugSession implements IEmmyStackContext 
             this.listenMode = true;
             const socket = net.createServer(client => {
                 this.client = client;
-                readline.createInterface({
-                    input: <NodeJS.ReadableStream> client,
-                    output: client
-                })
-                .on("line", line => this.onReceiveLine(line));
                 this.sendResponse(response);
                 this.onConnect(this.client);
                 this.readClient(client);


### PR DESCRIPTION
现像:
如果 VSCode 作为 Listener 模式下 (ideConnectDebugger = false)， 监听者会处理两次 Debugger 传过来的 Cmd
如果 VSCode 和 Debuger 在同一台机器上没问题，收到的次序是 cmd, stack, cmd, stack， 所以表现没问题（虽然多处理了一次）
但如果 Debugger 在另一台机器上(远程调试)，收到的次序可能是 cmd, cmd, stack, stack ， 少部分次序是 cmd, stack, cmd, stack，具体原因可能是  readline 库的处理不同。

解决：
移除不需要的监听 (相同的事在 readClient 做了)