### PR TITLE
解决windows平台下，相对路径以斜杠开头时无法找到文件的问题

### DIFF
--- a/src/debugger/DebugSession.ts
+++ b/src/debugger/DebugSession.ts
@@ -1,6 +1,6 @@
 import { LoggingDebugSession, Event, OutputEvent } from "vscode-debugadapter";
 import { DebugProtocol } from "vscode-debugprotocol";
-import * as path from 'path';
+//import * as path from 'path';
 
 export abstract class DebugSession extends LoggingDebugSession {
     constructor() {
@@ -32,9 +32,9 @@ export abstract class DebugSession extends LoggingDebugSession {
     }
 
     async findFile(file: string): Promise<string> {
-        if (path.isAbsolute(file)) {
-            return file;
-		}
+        //if (path.isAbsolute(file)) {
+        //    return file;
+		//}
         const r = this._fileCache.get(file);
         if (r) {
             return r;

--- a/src/debugger/DebuggerProvider.ts
+++ b/src/debugger/DebuggerProvider.ts
@@ -1,6 +1,17 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 
+var isWin = process.platform === "win32";
+
+function IsAbsolutePath(strPath: string): boolean {
+    if (isWin && strPath.length >= 1)
+    {
+        if ((strPath.charAt(0) == '\\' || strPath.charAt(0) == '/') && !(strPath.length >= 2 && strPath.charAt(0) == strPath.charAt(1)))
+            strPath = strPath.substr(1);
+    }
+    return path.isAbsolute(strPath);
+}
+
 export abstract class DebuggerProvider implements vscode.DebugConfigurationProvider, vscode.Disposable {
     constructor(
         protected type: string,
@@ -60,7 +71,7 @@ export abstract class DebuggerProvider implements vscode.DebugConfigurationProvi
             let results: string[] = [];
 
             for (const fileName of fileNames) {
-                if (path.isAbsolute(fileName)) {
+                if (IsAbsolutePath(fileName)) {
                     results = [fileName];
                     break;
                 }

--- a/src/debugger/DebuggerProvider.ts
+++ b/src/debugger/DebuggerProvider.ts
@@ -4,9 +4,9 @@ import * as path from 'path';
 const isWin = process.platform === "win32";
 
 function isAbsolutePath(strPath: string): boolean {
-    if (isWin && strPath.length >= 1)
+    if (isWin)
     {
-        if ((strPath.charAt(0) == '\\' || strPath.charAt(0) == '/') && !(strPath.startsWith("\\\\") || strPath.startsWith("//")))
+        if ((strPath.startsWith("\\") && !strPath.startsWith("\\\\")) || (strPath.startsWith("/") && !strPath.startsWith("//")))
             strPath = strPath.substr(1);
     }
     return path.isAbsolute(strPath);

--- a/src/debugger/DebuggerProvider.ts
+++ b/src/debugger/DebuggerProvider.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 
-var isWin = process.platform === "win32";
+const isWin = process.platform === "win32";
 
-function IsAbsolutePath(strPath: string): boolean {
+function isAbsolutePath(strPath: string): boolean {
     if (isWin && strPath.length >= 1)
     {
-        if ((strPath.charAt(0) == '\\' || strPath.charAt(0) == '/') && !(strPath.length >= 2 && strPath.charAt(0) == strPath.charAt(1)))
+        if ((strPath.charAt(0) == '\\' || strPath.charAt(0) == '/') && !(strPath.startsWith("\\\\") || strPath.startsWith("//")))
             strPath = strPath.substr(1);
     }
     return path.isAbsolute(strPath);
@@ -71,7 +71,7 @@ export abstract class DebuggerProvider implements vscode.DebugConfigurationProvi
             let results: string[] = [];
 
             for (const fileName of fileNames) {
-                if (IsAbsolutePath(fileName)) {
+                if (isAbsolutePath(fileName)) {
                     results = [fileName];
                     break;
                 }


### PR DESCRIPTION
path.isAbsolute 接口在windows平台上会将斜杠开头的路径也认为是绝对路径
这个修改特判了windows版本