### PR TITLE
Update the prototype of `assert()`, replace `any` with the generic `T`

### DIFF
--- a/res/std/global.lua
+++ b/res/std/global.lua
@@ -17,10 +17,9 @@
 --- **false**); otherwise, returns all its arguments. In case of error,
 --- `message` is the error object; when absent, it defaults to "assertion
 --- failed!"
----@overload fun(v:T):T
 ---@generic T
 ---@param v T
----@param message string
+---@param message? string
 ---@return T
 function assert(v, message) end
 

--- a/res/std/global.lua
+++ b/res/std/global.lua
@@ -17,10 +17,11 @@
 --- **false**); otherwise, returns all its arguments. In case of error,
 --- `message` is the error object; when absent, it defaults to "assertion
 --- failed!"
----@overload fun(v:any):any
----@param v any
+---@overload fun(v:T):T
+---@generic T
+---@param v T
 ---@param message string
----@return any
+---@return T
 function assert(v, message) end
 
 ---


### PR DESCRIPTION
修改 lua 标准库的 `assert()` 函数的原型(注解)，将 `类型any` 改为 `泛型T`。

---

避免一个对象被 assert() 包了一层后，丢失类型信息，比如 `local obj = assert(getObj())`。