### PR TITLE
修复调试器在一些特殊目录结构中会找错同名文件的bug 

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,0 @@
-node ./build/prepare-version.js
-node ./build/prepare.js
-vsce package -o VSCode-EmmyLua.vsix

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,1 @@
+vsce package

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,3 @@
-vsce package
+node ./build/prepare-version.js
+node ./build/prepare.js
+vsce package -o VSCode-EmmyLua.vsix

--- a/src/debugger/base/DebuggerProvider.ts
+++ b/src/debugger/base/DebuggerProvider.ts
@@ -89,7 +89,7 @@ export abstract class DebuggerProvider implements vscode.DebugConfigurationProvi
                     while (parts.length >= 2) {
                         parts = parts.slice(1);
                         const matchFile = path.join("**", ...parts)
-                        uris = await vscode.workspace.findFiles(matchFile, null, 1);
+                        uris = await vscode.workspace.findFiles(matchFile, null, 10);
                         if (uris.length !== 0) {
                             break;
                         }
@@ -100,6 +100,10 @@ export abstract class DebuggerProvider implements vscode.DebugConfigurationProvi
                     results = uris.map(it => it.fsPath);
                     break;
                 }
+            }
+            
+            if (results.length !== 0) {
+                results = results.sort((a, b) => a.length - b.length)
             }
 
             e.session.customRequest('findFileRsp', { files: results, seq: seq });


### PR DESCRIPTION
例子：
调试器给出 \ui\Config\Default\Target.lua
实际有两个同名文件：
\ui\Config\Default\Target.lua
\ui\Traits\mobilestreaming\Config\Default\Target.lua
会找成下面这个