### PR TITLE
Automatically insert space when line breaking in a comment

### DIFF
--- a/src/languageConfiguration.ts
+++ b/src/languageConfiguration.ts
@@ -41,6 +41,10 @@ export class LuaLanguageConfiguration implements LanguageConfiguration {
         if (autoInsertTripleDash) {
             this.onEnterRules = [
                 {
+                    action: { indentAction: IndentAction.None, appendText: "--- " },
+                    beforeText: /^--- /,
+                },
+                {
                     action: { indentAction: IndentAction.None, appendText: "---" },
                     beforeText: /^---/,
                 },


### PR DESCRIPTION
Added a setting to detect if previous comment starts with a space, and add a space on line break.