### PR TITLE
Add backticks to the set of supported parentheses

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -6,21 +6,24 @@
 	"brackets": [
 		["[", "]"],
 		["(", ")"],
-		["{", "}"]
+		["{", "}"],
+		["`", "`"]
 	],
 	"autoClosingPairs": [
 		{ "open": "[", "close": "]" },
 		{ "open": "(", "close": ")" },
 		{ "open": "{", "close": "}", "notIn": ["string", "comment"] },
 		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
-		{ "open": "\"", "close": "\"", "notIn": ["string"] }
+		{ "open": "\"", "close": "\"", "notIn": ["string"] },
+		{ "open": "`", "close": "`" }
 	],
 	"surroundingPairs": [
 		["[", "]"],
 		["(", ")"],
 		["{", "}"],
 		["\"", "\""],
-		["'", "'"]
+		["'", "'"],
+		["`", "`"]
 	],
 	"folding": {
 		"markers": {


### PR DESCRIPTION
With proper markdown support, it makes sense to recognize backticks (`` ` ``) as parentheses. This will make VSCode automatically close them and allow adding them around selections.