### PR TITLE
Add `emmylua.language.completeAnnotation` to config renames spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -994,6 +994,12 @@
                         "type": "boolean",
                         "default": true,
                         "markdownDescription": "%config.emmylua.language.completeAnnotation.description%"
+                    },
+                    "emmylua.misc.autoInsertTripleDash": {
+                        "type": "boolean",
+                        "default": true,
+                        "markdownDescription": "%config.emmylua.language.completeAnnotation.description%",
+                        "deprecationMessage": "Use `emmylua.language.completeAnnotation` instead"
                     }
                 }
             },

--- a/src/configRenames.ts
+++ b/src/configRenames.ts
@@ -4,6 +4,7 @@ const RENAMES: Record<string, string> = {
     "emmylua.colors.mutableUnderline": "emmylua.colors.mutable_underline",
     "emmylua.ls.executablePath": "emmylua.misc.executablePath",
     "emmylua.ls.globalConfigPath": "emmylua.misc.globalConfigPath",
+    "emmylua.language.completeAnnotation": "emmylua.misc.autoInsertTripleDash",
 };
 
 export function get<T>(

--- a/src/languageConfiguration.ts
+++ b/src/languageConfiguration.ts
@@ -1,5 +1,6 @@
 import { LanguageConfiguration, IndentAction, IndentationRule } from "vscode";
 import { workspace } from "vscode";
+import { get } from "./configRenames";
 export class LuaLanguageConfiguration implements LanguageConfiguration {
     public onEnterRules: any[];
 
@@ -36,7 +37,7 @@ export class LuaLanguageConfiguration implements LanguageConfiguration {
             undefined,
             workspace.workspaceFolders?.[0]
         );
-        const completeAnnotation = config.get<boolean>('emmylua.language.completeAnnotation', true);
+        const completeAnnotation = get<boolean>(config, 'emmylua.language.completeAnnotation') ?? true;
         // 第二个参数是默认值（当配置不存在时使用）
         if (completeAnnotation) {
             this.onEnterRules = [


### PR DESCRIPTION
I've recently added functionality for processing renames in config parameters (see `src/configRenames.ts`). It ensures that users with old parameter names in their configs don't loose their configuration upon update. Please, use it in future when renaming options. cc @CppCXY @xuhuanzy.