### PR TITLE
Add release script to keep schema, translations and setting in sync

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -1,6 +1,0 @@
-exports.default = {
-    emmyDebuggerVersion: '1.8.6',
-    emmyDebuggerUrl: 'https://github.com/EmmyLua/EmmyLuaDebugger/releases/download',
-    newLanguageServerVersion: "0.11.0",
-    newLanguageServerUrl: "https://github.com/CppCXY/emmylua-analyzer-rust/releases/download"
-}

--- a/build/config.json
+++ b/build/config.json
@@ -1,0 +1,7 @@
+{
+    "emmyDebuggerVersion": "1.8.6",
+    "emmyDebuggerUrl": "https://github.com/EmmyLua/EmmyLuaDebugger/releases/download",
+    "newLanguageServerVersion": "0.11.0",
+    "newLanguageServerUrl": "https://github.com/CppCXY/emmylua-analyzer-rust/releases/download",
+    "newLanguageServerSchemaUrl": "https://raw.githubusercontent.com/EmmyLuaLs/emmylua-analyzer-rust/refs/tags/{{tag}}/crates/emmylua_code_analysis/resources/schema.json"
+}

--- a/build/package.json
+++ b/build/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/build/prepare.js
+++ b/build/prepare.js
@@ -1,50 +1,63 @@
-const fs = require('fs');
-const download = require('download');
-const decompress = require('decompress')
-const decompressTargz = require('decompress-targz')
-const fc = require('filecopy');
-const config = require('./config').default;
-const args = process.argv;
+import { existsSync, mkdirSync } from "fs";
+import decompress from "decompress";
+import decompressTarGz from "decompress-targz";
+import config from "./config.json" with { type: "json" };
+import { downloadTo } from "./util.js";
 
-async function downloadTo(url, path) {
-    return new Promise((r, e) => {
-        const d = download(url);
-        d.then(r).catch(err => e(err));
-        d.pipe(fs.createWriteStream(path));
-    });
-}
+const args = process.argv;
 
 async function downloadDepends() {
     await Promise.all([
-        downloadTo(`${config.emmyDebuggerUrl}/${config.emmyDebuggerVersion}/linux-x64.zip`, 'temp/linux-x64.zip'),
-        downloadTo(`${config.emmyDebuggerUrl}/${config.emmyDebuggerVersion}/darwin-arm64.zip`, 'temp/darwin-arm64.zip'),
-        downloadTo(`${config.emmyDebuggerUrl}/${config.emmyDebuggerVersion}/darwin-x64.zip`, 'temp/darwin-x64.zip'),
-        downloadTo(`${config.emmyDebuggerUrl}/${config.emmyDebuggerVersion}/win32-x86.zip`, 'temp/win32-x86.zip'),
-        downloadTo(`${config.emmyDebuggerUrl}/${config.emmyDebuggerVersion}/win32-x64.zip`, 'temp/win32-x64.zip'),
-        downloadTo(`${config.newLanguageServerUrl}/${config.newLanguageServerVersion}/${args[2]}`, `temp/${args[2]}`)
+        downloadTo(
+            `${config.emmyDebuggerUrl}/${config.emmyDebuggerVersion}/linux-x64.zip`,
+            "temp/linux-x64.zip"
+        ),
+        downloadTo(
+            `${config.emmyDebuggerUrl}/${config.emmyDebuggerVersion}/darwin-arm64.zip`,
+            "temp/darwin-arm64.zip"
+        ),
+        downloadTo(
+            `${config.emmyDebuggerUrl}/${config.emmyDebuggerVersion}/darwin-x64.zip`,
+            "temp/darwin-x64.zip"
+        ),
+        downloadTo(
+            `${config.emmyDebuggerUrl}/${config.emmyDebuggerVersion}/win32-x86.zip`,
+            "temp/win32-x86.zip"
+        ),
+        downloadTo(
+            `${config.emmyDebuggerUrl}/${config.emmyDebuggerVersion}/win32-x64.zip`,
+            "temp/win32-x64.zip"
+        ),
+        downloadTo(
+            `${config.newLanguageServerUrl}/${config.newLanguageServerVersion}/${args[2]}`,
+            `temp/${args[2]}`
+        ),
+        downloadTo(`${newLanguageServerSchemaUrl}`, schemaPath),
     ]);
 }
 
 async function build() {
-    if (!fs.existsSync('temp')) {
-        fs.mkdirSync('temp')
+    if (!existsSync("temp")) {
+        mkdirSync("temp");
     }
 
     await downloadDepends();
 
     // linux
-    await decompress('temp/linux-x64.zip', 'debugger/emmy/linux/');
+    await decompress("temp/linux-x64.zip", "debugger/emmy/linux/");
     // mac
-    await decompress('temp/darwin-x64.zip', 'debugger/emmy/mac/x64/');
-    await decompress('temp/darwin-arm64.zip', 'debugger/emmy/mac/arm64/');
+    await decompress("temp/darwin-x64.zip", "debugger/emmy/mac/x64/");
+    await decompress("temp/darwin-arm64.zip", "debugger/emmy/mac/arm64/");
     // win
-    await decompress('temp/win32-x86.zip', 'debugger/emmy/windows/x86/');
-    await decompress('temp/win32-x64.zip', 'debugger/emmy/windows/x64/');
+    await decompress("temp/win32-x86.zip", "debugger/emmy/windows/x86/");
+    await decompress("temp/win32-x64.zip", "debugger/emmy/windows/x64/");
 
     // new ls
-    if (args[2].endsWith('.tar.gz')) {
-        await decompress(`temp/${args[2]}`, `server/`, { plugins: [decompressTargz()] });
-    } else if (args[2].endsWith('.zip')) {
+    if (args[2].endsWith(".tar.gz")) {
+        await decompress(`temp/${args[2]}`, `server/`, {
+            plugins: [decompressTarGz()],
+        });
+    } else if (args[2].endsWith(".zip")) {
         await decompress(`temp/${args[2]}`, `server/`);
     }
 }

--- a/build/release.js
+++ b/build/release.js
@@ -1,0 +1,69 @@
+import { exit } from "process";
+import config from "./config.json" with { type: "json" };
+import {
+    downloadTo,
+    writeConfig,
+    readPackage,
+    writePackage,
+    schemaPath,
+} from "./util.js";
+import { main as syncSettings } from "./settings.js";
+import { main as syncSchemaI18n } from "./schema-i18n.js";
+
+const args = process.argv;
+
+async function main() {
+    const version = args[2];
+    if (!version) {
+        console.error(
+            "Usage: npm run release -- <version> [<language-server-version>]"
+        );
+        exit(1);
+    }
+    if (!/\d+\.\d+\.\d+/.test(version)) {
+        console.error(
+            `Incorrect version: expected format '1.2.3', got ${version}`
+        );
+        exit(1);
+    }
+
+    let languageServerVersion = args[3];
+    if (!languageServerVersion) {
+        languageServerVersion = config.newLanguageServerVersion;
+    }
+    if (!/\d+\.\d+\.\d+/.test(languageServerVersion)) {
+        console.error(
+            "Incorrect language-server-version: expected format '1.2.3'"
+        );
+        exit(1);
+    }
+
+    {
+        console.log("Updating 'build/config.json'...");
+        config.newLanguageServerVersion = languageServerVersion;
+        writeConfig(config);
+    }
+
+    {
+        console.log("Updating 'package.json'...");
+        const packageJson = readPackage();
+        packageJson["version"] = version;
+        writePackage(packageJson);
+    }
+
+    const newLanguageServerSchemaUrl =
+        config.newLanguageServerSchemaUrl.replace(
+            /\{\{\s*tag\s*\}\}/g,
+            config.newLanguageServerVersion
+        );
+    console.log("Downloading new schema to 'syntaxes/schema.json'...");
+    await downloadTo(newLanguageServerSchemaUrl, schemaPath);
+
+    console.log("Processing new schema...");
+    syncSettings();
+    syncSchemaI18n();
+
+    console.log(`✅ release ${version} successfully prepared`);
+}
+
+await main();

--- a/build/schema-i18n.js
+++ b/build/schema-i18n.js
@@ -1,44 +1,54 @@
-const fs = require('fs');
-const path = require('path');
+import {
+    readSchema,
+    readSchemaI18n,
+    schemaPathI18n,
+    writeSchemaI18n,
+    writeSchemaZhCn,
+} from "./util.js";
+import { existsSync } from "fs";
 
 function buildCleanPath(currentPath, currentObj) {
-    if (typeof currentPath !== 'string') {
-        return '';
+    if (typeof currentPath !== "string") {
+        return "";
     }
 
     let cleanPath = currentPath
-        .replace(/\.properties\./g, '.')
-        .replace(/\.oneOf\.\d+/g, '')
-        .replace(/\.allOf\.\d+/g, '')
-        .replace(/\.items/g, '')
-        .replace(/\.additionalProperties/g, '')
-        .replace(/^\.|\.$/g, '')
-        .replace(/\.$/, '');
+        .replace(/\.properties\./g, ".")
+        .replace(/\.oneOf\.\d+/g, "")
+        .replace(/\.allOf\.\d+/g, "")
+        .replace(/\.items/g, "")
+        .replace(/\.additionalProperties/g, "")
+        .replace(/^\.|\.$/g, "")
+        .replace(/\.$/, "");
 
-    if (currentPath.includes('.oneOf.') && currentObj && Object.prototype.hasOwnProperty.call(currentObj, 'const')) {
+    if (
+        currentPath.includes(".oneOf.") &&
+        currentObj &&
+        Object.prototype.hasOwnProperty.call(currentObj, "const")
+    ) {
         const enumValue = currentObj.const;
-        cleanPath = cleanPath + '.' + enumValue;
+        cleanPath = cleanPath + "." + enumValue;
     }
 
     return cleanPath;
 }
 
-function extractDescriptions(obj, currentPath = '', result = {}) {
-    if (typeof obj !== 'object' || obj === null) {
+function extractDescriptions(obj, currentPath = "", result = {}) {
+    if (typeof obj !== "object" || obj === null) {
         return result;
     }
 
     for (const [key, value] of Object.entries(obj)) {
-        if (key === 'description' && typeof value === 'string') {
+        if (key === "description" && typeof value === "string") {
             // 生成简化的路径，忽略 properties、oneOf、allOf 等中间路径
             const cleanPath = buildCleanPath(currentPath, obj);
 
             if (cleanPath) {
                 result[cleanPath] = {
-                    "en": value
+                    en: value,
                 };
             }
-        } else if (typeof value === 'object') {
+        } else if (typeof value === "object") {
             const newPath = currentPath ? `${currentPath}.${key}` : key;
             extractDescriptions(value, newPath, result);
         }
@@ -55,8 +65,10 @@ function mergeWithExistingTranslations(newDescriptions, existingI18n) {
 
         // 如果现有文件中存在这个key，将非"en"的所有语言key都附加过来
         if (existingI18n[key]) {
-            for (const [langKey, langValue] of Object.entries(existingI18n[key])) {
-                if (langKey !== 'en') {
+            for (const [langKey, langValue] of Object.entries(
+                existingI18n[key]
+            )) {
+                if (langKey !== "en") {
                     merged[key][langKey] = langValue;
                 }
             }
@@ -66,25 +78,29 @@ function mergeWithExistingTranslations(newDescriptions, existingI18n) {
     return merged;
 }
 
-function translateDescriptions(obj, i18nData, currentPath = '') {
-    if (typeof obj !== 'object' || obj === null) {
+function translateDescriptions(obj, i18nData, currentPath = "") {
+    if (typeof obj !== "object" || obj === null) {
         return obj;
     }
 
     const result = Array.isArray(obj) ? [] : {};
 
     for (const [key, value] of Object.entries(obj)) {
-        if (key === 'description' && typeof value === 'string') {
+        if (key === "description" && typeof value === "string") {
             // 生成简化的路径来查找翻译
             const cleanPath = buildCleanPath(currentPath, obj);
 
             // 查找中文翻译
-            if (cleanPath && i18nData[cleanPath] && i18nData[cleanPath]['zh-CN']) {
-                result[key] = i18nData[cleanPath]['zh-CN'];
+            if (
+                cleanPath &&
+                i18nData[cleanPath] &&
+                i18nData[cleanPath]["zh-CN"]
+            ) {
+                result[key] = i18nData[cleanPath]["zh-CN"];
             } else {
                 result[key] = value; // 保持原文
             }
-        } else if (typeof value === 'object') {
+        } else if (typeof value === "object") {
             const newPath = currentPath ? `${currentPath}.${key}` : key;
             result[key] = translateDescriptions(value, i18nData, newPath);
         } else {
@@ -95,63 +111,58 @@ function translateDescriptions(obj, i18nData, currentPath = '') {
     return result;
 }
 
-function main() {
-    try {
-        // 读取 schema.json 文件
-        const schemaPath = path.join(__dirname, '..', 'syntaxes', 'schema.json');
-        const schemaContent = fs.readFileSync(schemaPath, 'utf-8');
-        const schema = JSON.parse(schemaContent);
+export function main() {
+    // 读取 schema.json 文件
+    const schema = readSchema();
 
-        // 只处理 definitions 部分
-        const definitions = schema.$defs || {};
+    // 只处理 definitions 部分
+    const definitions = schema.$defs || {};
 
-        // 提取所有 description
-        const descriptions = extractDescriptions(definitions);
+    // 提取所有 description
+    const descriptions = extractDescriptions(definitions);
 
-        // 排序结果
-        const sortedDescriptions = {};
-        Object.keys(descriptions).sort().forEach(key => {
+    // 排序结果
+    const sortedDescriptions = {};
+    Object.keys(descriptions)
+        .sort()
+        .forEach((key) => {
             sortedDescriptions[key] = descriptions[key];
         });
 
-        // 读取现有的 schema.i18n.json 文件
-        const i18nPath = path.join(__dirname, '..', 'syntaxes', 'schema.i18n.json');
-        let existingI18n = {};
+    // 读取现有的 schema.i18n.json 文件
+    let existingI18n = {};
 
-        if (fs.existsSync(i18nPath)) {
-            try {
-                const existingContent = fs.readFileSync(i18nPath, 'utf-8');
-                existingI18n = JSON.parse(existingContent);
-                console.log('已读取现有的 schema.i18n.json 文件');
-            } catch (error) {
-                console.log('读取现有 schema.i18n.json 文件失败，将创建新文件');
-            }
-        } else {
-            console.log('未找到现有的 schema.i18n.json 文件，将创建新文件');
+    if (existsSync(schemaPathI18n)) {
+        try {
+            existingI18n = readSchemaI18n();
+            console.log("已读取现有的 schema.i18n.json 文件");
+        } catch (error) {
+            console.log("读取现有 schema.i18n.json 文件失败，将创建新文件");
         }
-
-        // 合并翻译内容
-        const finalDescriptions = mergeWithExistingTranslations(sortedDescriptions, existingI18n);
-
-        // 更新 schema.i18n.json 文件
-        fs.writeFileSync(i18nPath, JSON.stringify(finalDescriptions, null, 2));
-        console.log(`已更新 schema.i18n.json 文件`);
-
-        // 生成中文版的 schema.zh-cn.json（只处理 definitions 部分）
-        const translatedDefinitions = translateDescriptions(schema.$defs, finalDescriptions);
-        const translatedSchema = {
-            ...schema,
-            $defs: translatedDefinitions
-        };
-
-        const zhCnPath = path.join(__dirname, '..', 'syntaxes', 'schema.zh-cn.json');
-        fs.writeFileSync(zhCnPath, JSON.stringify(translatedSchema, null, 2));
-        console.log(`已生成中文版 schema.zh-cn.json 文件`);
-
-        console.log('\n✅ 处理完成！');
-    } catch (error) {
-        console.error('错误:', error.message);
+    } else {
+        console.log("未找到现有的 schema.i18n.json 文件，将创建新文件");
     }
-}
 
-main();
+    // 合并翻译内容
+    const finalDescriptions = mergeWithExistingTranslations(
+        sortedDescriptions,
+        existingI18n
+    );
+
+    // 更新 schema.i18n.json 文件
+    writeSchemaI18n(finalDescriptions);
+    console.log(`已更新 schema.i18n.json 文件`);
+
+    // 生成中文版的 schema.zh-cn.json（只处理 definitions 部分）
+    const translatedDefinitions = translateDescriptions(
+        schema.$defs,
+        finalDescriptions
+    );
+    const translatedSchema = {
+        ...schema,
+        $defs: translatedDefinitions,
+    };
+
+    writeSchemaZhCn(translatedSchema);
+    console.log(`已生成中文版 schema.zh-cn.json 文件`);
+}

--- a/build/util.js
+++ b/build/util.js
@@ -1,0 +1,68 @@
+import { join } from "path";
+import { readFileSync, writeFileSync, createWriteStream } from "fs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import download from "download";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export async function downloadTo(url, path) {
+    return new Promise((r, e) => {
+        const d = download(url);
+        d.then(r).catch((err) => e(err));
+        d.pipe(createWriteStream(path));
+    });
+}
+
+export function ensureNl(s) {
+    if (!s.endsWith("\n")) {
+        s += "\n";
+    }
+    return s;
+}
+
+export function readJson(path) {
+    return JSON.parse(readFileSync(path));
+}
+
+export function writeJson(path, data) {
+    writeFileSync(path, ensureNl(JSON.stringify(data, null, 4)));
+}
+
+export const schemaPath = join(__dirname, "..", "syntaxes", "schema.json");
+export const readSchema = () => readJson(schemaPath);
+export const writeSchema = (data) => writeJson(schemaPath, data);
+
+export const schemaPathZhCn = join(
+    __dirname,
+    "..",
+    "syntaxes",
+    "schema.zh-cn.json"
+);
+export const readSchemaZhCn = () => readJson(schemaPathZhCn);
+export const writeSchemaZhCn = (data) => writeJson(schemaPathZhCn, data);
+
+export const schemaPathI18n = join(
+    __dirname,
+    "..",
+    "syntaxes",
+    "schema.i18n.json"
+);
+export const readSchemaI18n = () => readJson(schemaPathI18n);
+export const writeSchemaI18n = (data) => writeJson(schemaPathI18n, data);
+
+export const localePathDefault = join(__dirname, "..", "package.nls.json");
+export const readLocaleDefault = () => readJson(localePathDefault);
+export const writeLocaleDefault = (data) => writeJson(localePathDefault, data);
+
+export const localePathZhCn = join(__dirname, "..", "package.nls.zh-cn.json");
+export const readLocaleZhCn = () => readJson(localePathZhCn);
+export const writeLocaleZhCn = (data) => writeJson(localePathZhCn, data);
+
+export const packagePath = join(__dirname, "..", "package.json");
+export const readPackage = () => readJson(packagePath);
+export const writePackage = (data) => writeJson(packagePath, data);
+
+export const configPath = join(__dirname, "config.json");
+export const readConfig = () => readJson(configPath);
+export const writeConfig = (data) => writeJson(configPath, data);

--- a/package.json
+++ b/package.json
@@ -1196,7 +1196,8 @@
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
-        "test": "npm run compile && node ./node_modules/vscode/bin/test"
+        "test": "npm run compile && node ./node_modules/vscode/bin/test",
+        "release": "node --disable-warning=ExperimentalWarning ./build/release.js"
     },
     "devDependencies": {
         "@types/mocha": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -910,6 +910,29 @@
                         ],
                         "default": null,
                         "markdownDescription": "%config.emmylua.semanticTokens.enable.description%"
+                    },
+                    "emmylua.semanticTokens.renderDocumentationMarkup": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ],
+                        "enum": [
+                            null,
+                            true,
+                            false
+                        ],
+                        "enumItemLabels": [
+                            "Default",
+                            "On",
+                            "Off"
+                        ],
+                        "markdownEnumDescriptions": [
+                            "%config.common.enum.default.description%",
+                            "%config.common.enum.on.description%",
+                            "%config.common.enum.off.description%"
+                        ],
+                        "default": null,
+                        "markdownDescription": "%config.emmylua.semanticTokens.renderDocumentationMarkup.description%"
                     }
                 }
             },

--- a/package.nls.json
+++ b/package.nls.json
@@ -31,6 +31,7 @@
     "config.emmylua.references.fuzzySearch.description": "Use fuzzy search when searching for symbol usages\nand normal search didn't find anything.",
     "config.emmylua.references.shortStringSearch.description": "Also search for usages in strings.",
     "config.emmylua.semanticTokens.enable.description": "Enable semantic tokens.",
+    "config.emmylua.semanticTokens.renderDocumentationMarkup.description": "Render Markdown/RST in documentation. Set `doc.syntax` for this option to have effect.",
     "config.emmylua.workspace.enableReindex.description": "Enable full project reindex after changing a file.",
     "config.emmylua.workspace.reindexDuration.description": "Delay between changing a file and full project reindex, in milliseconds.",
     "config.lua.trace.server.description": "Traces the communication between VSCode and the EmmyLua language server in the Output view. Default is `off`",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -31,6 +31,7 @@
     "config.emmylua.references.fuzzySearch.description": "当普通搜索未找到任何内容时，使用模糊搜索查找符号用法。",
     "config.emmylua.references.shortStringSearch.description": "也在字符串中搜索用法。",
     "config.emmylua.semanticTokens.enable.description": "启用语义标记。",
+    "config.emmylua.semanticTokens.renderDocumentationMarkup.description": "Render Markdown/RST in documentation. Set `doc.syntax` for this option to have effect.",
     "config.emmylua.workspace.enableReindex.description": "更改文件后启用整个项目的重新索引。",
     "config.emmylua.workspace.reindexDuration.description": "更改文件与整个项目重新索引之间的延迟（毫秒）。",
     "config.lua.trace.server.description": "在输出视图中跟踪 VSCode 与 EmmyLua 语言服务器之间的通信。默认值为 `off`",

--- a/syntaxes/schema.i18n.json
+++ b/syntaxes/schema.i18n.json
@@ -1,469 +1,496 @@
 {
-  "ClassDefaultCall.forceNonColon": {
-    "en": "Mandatory non`:` definition. When `function_name` is not empty, it takes effect.",
-    "zh-CN": "强制非冒号定义。当 `function_name` 不为空时生效。"
-  },
-  "ClassDefaultCall.forceReturnSelf": {
-    "en": "Force to return `self`.",
-    "zh-CN": "强制返回 `self`。"
-  },
-  "ClassDefaultCall.functionName": {
-    "en": "class default overload function. eg. \"__init\".",
-    "zh-CN": "类默认重载函数。例如：\"__init\"。"
-  },
-  "DiagnosticCode.access-invisible": {
-    "en": "Access invisible",
-    "zh-CN": "成员可见性检查。"
-  },
-  "DiagnosticCode.annotation-usage-error": {
-    "en": "Doc tag usage error",
-    "zh-CN": "注解使用错误。"
-  },
-  "DiagnosticCode.assign-type-mismatch": {
-    "en": "Assign type mismatch",
-    "zh-CN": "赋值类型不匹配。"
-  },
-  "DiagnosticCode.await-in-sync": {
-    "en": "Await in sync",
-    "zh-CN": "在同步上下文中使用 await。"
-  },
-  "DiagnosticCode.cast-type-mismatch": {
-    "en": "cast-type-mismatch"
-  },
-  "DiagnosticCode.circle-doc-class": {
-    "en": "Circle Doc Class",
-    "zh-CN": "类型循环依赖。"
-  },
-  "DiagnosticCode.code-style-check": {
-    "en": "Code style check",
-    "zh-CN": "代码风格检查。"
-  },
-  "DiagnosticCode.deprecated": {
-    "en": "Deprecated",
-    "zh-CN": "已弃用。"
-  },
-  "DiagnosticCode.discard-returns": {
-    "en": "Discard return value",
-    "zh-CN": "不可丢弃返回值。"
-  },
-  "DiagnosticCode.doc-syntax-error": {
-    "en": "Doc syntax error",
-    "zh-CN": "注解语法错误。"
-  },
-  "DiagnosticCode.duplicate-doc-field": {
-    "en": "Duplicate doc field",
-    "zh-CN": "重复定义的字段(注解)。"
-  },
-  "DiagnosticCode.duplicate-index": {
-    "en": "duplicate-index",
-    "zh-CN": "重复的索引。"
-  },
-  "DiagnosticCode.duplicate-require": {
-    "en": "Duplicate require",
-    "zh-CN": "重复的 require 导入。"
-  },
-  "DiagnosticCode.duplicate-set-field": {
-    "en": "duplicate-set-field",
-    "zh-CN": "重复定义的字段(实际代码)。"
-  },
-  "DiagnosticCode.duplicate-type": {
-    "en": "Duplicate type",
-    "zh-CN": "重复定义的类型。"
-  },
-  "DiagnosticCode.enum-value-mismatch": {
-    "en": "enum-value-mismatch",
-    "zh-CN": "枚举值不匹配。"
-  },
-  "DiagnosticCode.generic-constraint-mismatch": {
-    "en": "generic-constraint-mismatch",
-    "zh-CN": "泛型约束不匹配。"
-  },
-  "DiagnosticCode.incomplete-signature-doc": {
-    "en": "Incomplete signature doc",
-    "zh-CN": "不完整的签名文档。"
-  },
-  "DiagnosticCode.inject-field": {
-    "en": "Inject Field",
-    "zh-CN": "注入字段。"
-  },
-  "DiagnosticCode.iter-variable-reassign": {
-    "en": "Iter variable reassign",
-    "zh-CN": "迭代变量重新赋值。"
-  },
-  "DiagnosticCode.local-const-reassign": {
-    "en": "Local const reassign",
-    "zh-CN": "局部常量重新赋值。"
-  },
-  "DiagnosticCode.missing-fields": {
-    "en": "Missing fields",
-    "zh-CN": "缺少字段。"
-  },
-  "DiagnosticCode.missing-global-doc": {
-    "en": "Missing global doc",
-    "zh-CN": "全局变量缺少文档。"
-  },
-  "DiagnosticCode.missing-parameter": {
-    "en": "Missing parameter",
-    "zh-CN": "缺少参数。"
-  },
-  "DiagnosticCode.missing-return": {
-    "en": "Missing return statement",
-    "zh-CN": "缺少返回语句。"
-  },
-  "DiagnosticCode.missing-return-value": {
-    "en": "Missing return value",
-    "zh-CN": "缺少返回值。"
-  },
-  "DiagnosticCode.need-check-nil": {
-    "en": "Need check nil",
-    "zh-CN": "需要检查 nil。"
-  },
-  "DiagnosticCode.non-literal-expressions-in-assert": {
-    "en": "non-literal-expressions-in-assert",
-    "zh-CN": "在 assert 中使用了非字面量表达式。"
-  },
-  "DiagnosticCode.param-type-not-match": {
-    "en": "Param Type not match",
-    "zh-CN": "参数类型不匹配。"
-  },
-  "DiagnosticCode.redefined-label": {
-    "en": "Redefined label",
-    "zh-CN": "重复定义的标签。"
-  },
-  "DiagnosticCode.redefined-local": {
-    "en": "Redefined local",
-    "zh-CN": "重复定义的局部变量。"
-  },
-  "DiagnosticCode.redundant-parameter": {
-    "en": "Redundant parameter",
-    "zh-CN": "冗余参数。"
-  },
-  "DiagnosticCode.redundant-return-value": {
-    "en": "Redundant return value",
-    "zh-CN": "冗余的返回值。"
-  },
-  "DiagnosticCode.require-module-not-visible": {
-    "en": "require-module-not-visible",
-    "zh-CN": "require 模块不可见。"
-  },
-  "DiagnosticCode.return-type-mismatch": {
-    "en": "Return type mismatch",
-    "zh-CN": "返回类型不匹配。"
-  },
-  "DiagnosticCode.syntax-error": {
-    "en": "Syntax error",
-    "zh-CN": "语法错误。"
-  },
-  "DiagnosticCode.type-not-found": {
-    "en": "Type not found",
-    "zh-CN": "类型未找到。"
-  },
-  "DiagnosticCode.unbalanced-assignments": {
-    "en": "Unbalanced assignments",
-    "zh-CN": "不平衡的赋值。"
-  },
-  "DiagnosticCode.undefined-doc-param": {
-    "en": "Undefined Doc Param",
-    "zh-CN": "未使用注解定义的参数。"
-  },
-  "DiagnosticCode.undefined-field": {
-    "en": "Undefined field",
-    "zh-CN": "未定义的字段。"
-  },
-  "DiagnosticCode.undefined-global": {
-    "en": "Undefined global",
-    "zh-CN": "未定义的全局变量。"
-  },
-  "DiagnosticCode.unknown-doc-tag": {
-    "en": "Unknown doc annotation",
-    "zh-CN": "未知文档注解。"
-  },
-  "DiagnosticCode.unnecessary-assert": {
-    "en": "unnecessary-assert",
-    "zh-CN": "不必要的 assert。"
-  },
-  "DiagnosticCode.unnecessary-if": {
-    "en": "unnecessary-if",
-    "zh-CN": "不必要的 if。"
-  },
-  "DiagnosticCode.unreachable-code": {
-    "en": "Unreachable code",
-    "zh-CN": "不可达的代码。"
-  },
-  "DiagnosticCode.unused": {
-    "en": "Unused",
-    "zh-CN": "未使用的变量。"
-  },
-  "DiagnosticSeveritySetting.error": {
-    "en": "Represents an error diagnostic severity.",
-    "zh-CN": "诊断严重性: 错误。"
-  },
-  "DiagnosticSeveritySetting.hint": {
-    "en": "Represents a hint diagnostic severity.",
-    "zh-CN": "诊断严重性: 提示。"
-  },
-  "DiagnosticSeveritySetting.information": {
-    "en": "Represents an information diagnostic severity.",
-    "zh-CN": "诊断严重性: 信息。"
-  },
-  "DiagnosticSeveritySetting.warning": {
-    "en": "Represents a warning diagnostic severity.",
-    "zh-CN": "诊断严重性: 警告。"
-  },
-  "EmmyrcCodeAction.insertSpace": {
-    "en": "Add space after `---` comments when inserting `@diagnostic disable-next-line`.",
-    "zh-CN": "是否在 '---' 后插入空格。"
-  },
-  "EmmyrcCodeLens.enable": {
-    "en": "Enable code lens."
-  },
-  "EmmyrcCompletion": {
-    "en": "Configuration for EmmyLua code completion.",
-    "zh-CN": "EmmyLua 代码补全配置。"
-  },
-  "EmmyrcCompletion.autoRequire": {
-    "en": "Automatically insert call to `require` when autocompletion\ninserts objects from other modules.",
-    "zh-CN": "自动补全 require 语句。"
-  },
-  "EmmyrcCompletion.autoRequireFunction": {
-    "en": "The function used for auto-requiring modules.",
-    "zh-CN": "自动补全 require 语句时使用的函数名。"
-  },
-  "EmmyrcCompletion.autoRequireNamingConvention": {
-    "en": "The naming convention for auto-required filenames.",
-    "zh-CN": "自动补全 require 语句时使用的命名规范。"
-  },
-  "EmmyrcCompletion.autoRequireSeparator": {
-    "en": "A separator used in auto-require paths.",
-    "zh-CN": "自动补全 require 语句时使用的分隔符。"
-  },
-  "EmmyrcCompletion.baseFunctionIncludesName": {
-    "en": "Whether to include the name in the base function completion. Effect: `function () end` -> `function name() end`.",
-    "zh-CN": "是否在基本函数补全中包含函数名。效果: `function () end` -> `function name() end`。"
-  },
-  "EmmyrcCompletion.callSnippet": {
-    "en": "Whether to use call snippets in completions.",
-    "zh-CN": "是否使用代码片段补全函数调用。"
-  },
-  "EmmyrcCompletion.enable": {
-    "en": "Enable autocompletion.",
-    "zh-CN": "是否启用代码补全。"
-  },
-  "EmmyrcCompletion.postfix": {
-    "en": "Symbol that's used to trigger postfix autocompletion.",
-    "zh-CN": "后缀补全触发关键词。"
-  },
-  "EmmyrcDiagnostic": {
-    "en": "Represents the diagnostic configuration for Emmyrc.",
-    "zh-CN": "Emmyrc 诊断配置。"
-  },
-  "EmmyrcDiagnostic.diagnosticInterval": {
-    "en": "Delay between opening/changing a file and scanning it for errors, in milliseconds.",
-    "zh-CN": "诊断间隔时间(毫秒)。"
-  },
-  "EmmyrcDiagnostic.disable": {
-    "en": "A list of diagnostic codes that are disabled.",
-    "zh-CN": "禁用的诊断代码列表。"
-  },
-  "EmmyrcDiagnostic.enable": {
-    "en": "A flag indicating whether diagnostics are enabled.",
-    "zh-CN": "是否启用诊断。"
-  },
-  "EmmyrcDiagnostic.enables": {
-    "en": "A list of diagnostic codes that are enabled.",
-    "zh-CN": "启用的诊断代码列表。"
-  },
-  "EmmyrcDiagnostic.globals": {
-    "en": "A list of global variables.",
-    "zh-CN": "全局变量列表，在该列表中的全局变量不会被诊断为未定义。"
-  },
-  "EmmyrcDiagnostic.globalsRegex": {
-    "en": "A list of regular expressions for global variables.",
-    "zh-CN": "全局变量正则表达式列表，符合正则表达式的全局变量不会被诊断为未定义。"
-  },
-  "EmmyrcDiagnostic.severity": {
-    "en": "A map of diagnostic codes to their severity settings.",
-    "zh-CN": "诊断代码与严重性设置的映射。"
-  },
-  "EmmyrcDoc.knownTags": {
-    "en": "List of known documentation tags.",
-    "zh-CN": "已知文档标签列表。"
-  },
-  "EmmyrcDoc.privateName": {
-    "en": "Treat specific field names as private, e.g. `m_*` means `XXX.m_id` and `XXX.m_type` are private, witch can only be accessed in the class where the definition is located.",
-    "zh-CN": "将特定字段名视为私有，例如 `m_*` 表示 `XXX.m_id` 和 `XXX.m_type` 是私有字段，只能在定义所在的类中访问。"
-  },
-  "EmmyrcDocumentColor.enable": {
-    "en": "Enable parsing strings for color tags and showing a color picker next to them.",
-    "zh-CN": "是否启用文档颜色。"
-  },
-  "EmmyrcFilenameConvention.camel-case": {
-    "en": "Convert the filename to camelCase.",
-    "zh-CN": "将文件名转换为驼峰(camelCase)命名。"
-  },
-  "EmmyrcFilenameConvention.keep": {
-    "en": "Keep the original filename.",
-    "zh-CN": "保持原始文件名。"
-  },
-  "EmmyrcFilenameConvention.keep-class": {
-    "en": "When returning class definition, use class name, otherwise keep original name.",
-    "zh-CN": "返回类定义时，使用类名，否则保持原始名称。"
-  },
-  "EmmyrcFilenameConvention.pascal-case": {
-    "en": "Convert the filename to PascalCase.",
-    "zh-CN": "将文件名转换为帕斯卡(PascalCase)命名。"
-  },
-  "EmmyrcFilenameConvention.snake-case": {
-    "en": "Convert the filename to snake_case.",
-    "zh-CN": "将文件名转换为蛇形(snake_case)命名。"
-  },
-  "EmmyrcHover.enable": {
-    "en": "Enable showing documentation on hover.",
-    "zh-CN": "是否启用悬浮提示。"
-  },
-  "EmmyrcInlayHint.enable": {
-    "en": "Enable inlay hints.",
-    "zh-CN": "是否启用内联提示。"
-  },
-  "EmmyrcInlayHint.enumParamHint": {
-    "en": "Show name of enumerator when passing a literal value to a function\nthat expects an enum.\n\nExample:\n\n```lua\n--- @enum Level\nlocal Foo = {\n   Info = 1,\n   Error = 2,\n}\n\n--- @param l Level\nfunction print_level(l) end\n\nprint_level(1 --[[ Hint: Level.Info ]])\n```",
-    "zh-CN": "是否启用枚举参数提示。"
-  },
-  "EmmyrcInlayHint.indexHint": {
-    "en": "Show named array indexes.\n\nExample:\n\n```lua\nlocal array = {\n   [1] = 1, -- [name]\n}\n\nprint(array[1] --[[ Hint: name ]])\n```",
-    "zh-CN": "在索引表达式跨行时，显示提示。"
-  },
-  "EmmyrcInlayHint.localHint": {
-    "en": "Show types of local variables.",
-    "zh-CN": "是否启用局部变量提示。"
-  },
-  "EmmyrcInlayHint.metaCallHint": {
-    "en": "Show hint when calling an object results in a call to\nits meta table's `__call` function.",
-    "zh-CN": "是否启用 `__call` 调用提示。"
-  },
-  "EmmyrcInlayHint.overrideHint": {
-    "en": "Show methods that override functions from base class.",
-    "zh-CN": "是否启用重写提示。"
-  },
-  "EmmyrcInlayHint.paramHint": {
-    "en": "Show parameter names in function calls and parameter types in function definitions.",
-    "zh-CN": "是否启用参数提示。"
-  },
-  "EmmyrcInlineValues.enable": {
-    "en": "Show inline values during debug.",
-    "zh-CN": "是否启用内联值。用于在调试断点时显示变量值。"
-  },
-  "EmmyrcLuaVersion.Lua5.1": {
-    "en": "Lua 5.1"
-  },
-  "EmmyrcLuaVersion.Lua5.2": {
-    "en": "Lua 5.2"
-  },
-  "EmmyrcLuaVersion.Lua5.3": {
-    "en": "Lua 5.3"
-  },
-  "EmmyrcLuaVersion.Lua5.4": {
-    "en": "Lua 5.4"
-  },
-  "EmmyrcLuaVersion.Lua5.5": {
-    "en": "Lua 5.5"
-  },
-  "EmmyrcLuaVersion.LuaJIT": {
-    "en": "LuaJIT"
-  },
-  "EmmyrcLuaVersion.LuaLatest": {
-    "en": "Lua Latest"
-  },
-  "EmmyrcReference.enable": {
-    "en": "Enable searching for symbol usages.",
-    "zh-CN": "是否启用引用搜索。"
-  },
-  "EmmyrcReference.fuzzySearch": {
-    "en": "Use fuzzy search when searching for symbol usages\nand normal search didn't find anything.",
-    "zh-CN": "是否启用模糊搜索。"
-  },
-  "EmmyrcReference.shortStringSearch": {
-    "en": "Also search for usages in strings.",
-    "zh-CN": "缓存短字符串用于搜索。"
-  },
-  "EmmyrcRuntime.classDefaultCall": {
-    "en": "class default overload function.",
-    "zh-CN": "类默认重载函数。"
-  },
-  "EmmyrcRuntime.extensions": {
-    "en": "file Extensions. eg: .lua, .lua.txt",
-    "zh-CN": "文件扩展名。例如：.lua, .lua.txt"
-  },
-  "EmmyrcRuntime.frameworkVersions": {
-    "en": "Framework versions.",
-    "zh-CN": "框架版本列表。"
-  },
-  "EmmyrcRuntime.requireLikeFunction": {
-    "en": "Functions that like require.",
-    "zh-CN": "类似 require 的函数列表。"
-  },
-  "EmmyrcRuntime.requirePattern": {
-    "en": "Require pattern. eg. \"?.lua\", \"?/init.lua\"",
-    "zh-CN": "require 模式。例如：\"?.lua\", \"?/init.lua\""
-  },
-  "EmmyrcRuntime.version": {
-    "en": "Lua version.",
-    "zh-CN": "Lua 版本。"
-  },
-  "EmmyrcSemanticToken.enable": {
-    "en": "Enable semantic tokens.",
-    "zh-CN": "是否启用语义标记。"
-  },
-  "EmmyrcSignature.detailSignatureHelper": {
-    "en": "Whether to enable signature help.",
-    "zh-CN": "是否启用签名帮助。"
-  },
-  "EmmyrcStrict.arrayIndex": {
-    "en": "Whether to enable strict mode array indexing.",
-    "zh-CN": "是否启用严格模式数组索引，严格模式下数组取值返回将包含 nil。"
-  },
-  "EmmyrcStrict.docBaseConstMatchBaseType": {
-    "en": "Base constant types defined in doc can match base types, allowing int to match `---@alias id 1|2|3`, same for string.",
-    "zh-CN": "doc定义的基础常量类型可以匹配基础类型，使 int 可以匹配 `---@alias id 1|2|3`，string 同理。"
-  },
-  "EmmyrcStrict.metaOverrideFileDefine": {
-    "en": "meta define overrides file define",
-    "zh-CN": "`---@meta`文件的定义完全覆盖真实文件的定义。"
-  },
-  "EmmyrcStrict.requirePath": {
-    "en": "Whether to enable strict mode require path.",
-    "zh-CN": "是否启用严格模式 require 路径。严格模式时 require 必须从指定的根目录开始。"
-  },
-  "EmmyrcWorkspace.enableReindex": {
-    "en": "Enable full project reindex after changing a file.",
-    "zh-CN": "启用重新索引。"
-  },
-  "EmmyrcWorkspace.encoding": {
-    "en": "Encoding. eg: \"utf-8\"",
-    "zh-CN": "编码。例如：\"utf-8\""
-  },
-  "EmmyrcWorkspace.ignoreDir": {
-    "en": "Ignore directories.",
-    "zh-CN": "忽略的目录。"
-  },
-  "EmmyrcWorkspace.ignoreGlobs": {
-    "en": "Ignore globs. eg: [\"**/*.lua\"]",
-    "zh-CN": "忽略的文件。例如：[\"**/*.lua\"]"
-  },
-  "EmmyrcWorkspace.library": {
-    "en": "Library paths. eg: \"/usr/local/share/lua/5.1\"",
-    "zh-CN": "库路径。例如：\"/usr/local/share/lua/5.1\""
-  },
-  "EmmyrcWorkspace.moduleMap": {
-    "en": "Module map. key is regex, value is new module regex\neg: {\n    \"^(.*)$\": \"module_$1\"\n    \"^lib(.*)$\": \"script$1\"\n}",
-    "zh-CN": "模块映射列表。key 是正则表达式，value 是新的模块正则表达式\n 例如：{\n    \"^(.*)$\": \"module_$1\"\n    \"^lib(.*)$\": \"script$1\"\n}"
-  },
-  "EmmyrcWorkspace.reindexDuration": {
-    "en": "Delay between changing a file and full project reindex, in milliseconds.",
-    "zh-CN": "当保存文件时，ls 将在指定毫秒后重新索引工作区。"
-  },
-  "EmmyrcWorkspace.workspaceRoots": {
-    "en": "Workspace roots. eg: [\"src\", \"test\"]",
-    "zh-CN": "工作区根目录列表。例如：[\"src\", \"test\"]"
-  }
+    "ClassDefaultCall.forceNonColon": {
+        "en": "Mandatory non`:` definition. When `function_name` is not empty, it takes effect.",
+        "zh-CN": "强制非冒号定义。当 `function_name` 不为空时生效。"
+    },
+    "ClassDefaultCall.forceReturnSelf": {
+        "en": "Force to return `self`.",
+        "zh-CN": "强制返回 `self`。"
+    },
+    "ClassDefaultCall.functionName": {
+        "en": "class default overload function. eg. \"__init\".",
+        "zh-CN": "类默认重载函数。例如：\"__init\"。"
+    },
+    "DiagnosticCode.access-invisible": {
+        "en": "Access invisible",
+        "zh-CN": "成员可见性检查。"
+    },
+    "DiagnosticCode.annotation-usage-error": {
+        "en": "Doc tag usage error",
+        "zh-CN": "注解使用错误。"
+    },
+    "DiagnosticCode.assign-type-mismatch": {
+        "en": "Assign type mismatch",
+        "zh-CN": "赋值类型不匹配。"
+    },
+    "DiagnosticCode.await-in-sync": {
+        "en": "Await in sync",
+        "zh-CN": "在同步上下文中使用 await。"
+    },
+    "DiagnosticCode.cast-type-mismatch": {
+        "en": "cast-type-mismatch"
+    },
+    "DiagnosticCode.circle-doc-class": {
+        "en": "Circle Doc Class",
+        "zh-CN": "类型循环依赖。"
+    },
+    "DiagnosticCode.code-style-check": {
+        "en": "Code style check",
+        "zh-CN": "代码风格检查。"
+    },
+    "DiagnosticCode.deprecated": {
+        "en": "Deprecated",
+        "zh-CN": "已弃用。"
+    },
+    "DiagnosticCode.discard-returns": {
+        "en": "Discard return value",
+        "zh-CN": "不可丢弃返回值。"
+    },
+    "DiagnosticCode.doc-syntax-error": {
+        "en": "Doc syntax error",
+        "zh-CN": "注解语法错误。"
+    },
+    "DiagnosticCode.duplicate-doc-field": {
+        "en": "Duplicate doc field",
+        "zh-CN": "重复定义的字段(注解)。"
+    },
+    "DiagnosticCode.duplicate-index": {
+        "en": "duplicate-index",
+        "zh-CN": "重复的索引。"
+    },
+    "DiagnosticCode.duplicate-require": {
+        "en": "Duplicate require",
+        "zh-CN": "重复的 require 导入。"
+    },
+    "DiagnosticCode.duplicate-set-field": {
+        "en": "duplicate-set-field",
+        "zh-CN": "重复定义的字段(实际代码)。"
+    },
+    "DiagnosticCode.duplicate-type": {
+        "en": "Duplicate type",
+        "zh-CN": "重复定义的类型。"
+    },
+    "DiagnosticCode.enum-value-mismatch": {
+        "en": "enum-value-mismatch",
+        "zh-CN": "枚举值不匹配。"
+    },
+    "DiagnosticCode.generic-constraint-mismatch": {
+        "en": "generic-constraint-mismatch",
+        "zh-CN": "泛型约束不匹配。"
+    },
+    "DiagnosticCode.incomplete-signature-doc": {
+        "en": "Incomplete signature doc",
+        "zh-CN": "不完整的签名文档。"
+    },
+    "DiagnosticCode.inject-field": {
+        "en": "Inject Field",
+        "zh-CN": "注入字段。"
+    },
+    "DiagnosticCode.iter-variable-reassign": {
+        "en": "Iter variable reassign",
+        "zh-CN": "迭代变量重新赋值。"
+    },
+    "DiagnosticCode.local-const-reassign": {
+        "en": "Local const reassign",
+        "zh-CN": "局部常量重新赋值。"
+    },
+    "DiagnosticCode.missing-fields": {
+        "en": "Missing fields",
+        "zh-CN": "缺少字段。"
+    },
+    "DiagnosticCode.missing-global-doc": {
+        "en": "Missing global doc",
+        "zh-CN": "全局变量缺少文档。"
+    },
+    "DiagnosticCode.missing-parameter": {
+        "en": "Missing parameter",
+        "zh-CN": "缺少参数。"
+    },
+    "DiagnosticCode.missing-return": {
+        "en": "Missing return statement",
+        "zh-CN": "缺少返回语句。"
+    },
+    "DiagnosticCode.missing-return-value": {
+        "en": "Missing return value",
+        "zh-CN": "缺少返回值。"
+    },
+    "DiagnosticCode.need-check-nil": {
+        "en": "Need check nil",
+        "zh-CN": "需要检查 nil。"
+    },
+    "DiagnosticCode.non-literal-expressions-in-assert": {
+        "en": "non-literal-expressions-in-assert",
+        "zh-CN": "在 assert 中使用了非字面量表达式。"
+    },
+    "DiagnosticCode.param-type-not-match": {
+        "en": "Param Type not match",
+        "zh-CN": "参数类型不匹配。"
+    },
+    "DiagnosticCode.redefined-label": {
+        "en": "Redefined label",
+        "zh-CN": "重复定义的标签。"
+    },
+    "DiagnosticCode.redefined-local": {
+        "en": "Redefined local",
+        "zh-CN": "重复定义的局部变量。"
+    },
+    "DiagnosticCode.redundant-parameter": {
+        "en": "Redundant parameter",
+        "zh-CN": "冗余参数。"
+    },
+    "DiagnosticCode.redundant-return-value": {
+        "en": "Redundant return value",
+        "zh-CN": "冗余的返回值。"
+    },
+    "DiagnosticCode.require-module-not-visible": {
+        "en": "require-module-not-visible",
+        "zh-CN": "require 模块不可见。"
+    },
+    "DiagnosticCode.return-type-mismatch": {
+        "en": "Return type mismatch",
+        "zh-CN": "返回类型不匹配。"
+    },
+    "DiagnosticCode.syntax-error": {
+        "en": "Syntax error",
+        "zh-CN": "语法错误。"
+    },
+    "DiagnosticCode.type-not-found": {
+        "en": "Type not found",
+        "zh-CN": "类型未找到。"
+    },
+    "DiagnosticCode.unbalanced-assignments": {
+        "en": "Unbalanced assignments",
+        "zh-CN": "不平衡的赋值。"
+    },
+    "DiagnosticCode.undefined-doc-param": {
+        "en": "Undefined Doc Param",
+        "zh-CN": "未使用注解定义的参数。"
+    },
+    "DiagnosticCode.undefined-field": {
+        "en": "Undefined field",
+        "zh-CN": "未定义的字段。"
+    },
+    "DiagnosticCode.undefined-global": {
+        "en": "Undefined global",
+        "zh-CN": "未定义的全局变量。"
+    },
+    "DiagnosticCode.unknown-doc-tag": {
+        "en": "Unknown doc annotation",
+        "zh-CN": "未知文档注解。"
+    },
+    "DiagnosticCode.unnecessary-assert": {
+        "en": "unnecessary-assert",
+        "zh-CN": "不必要的 assert。"
+    },
+    "DiagnosticCode.unnecessary-if": {
+        "en": "unnecessary-if",
+        "zh-CN": "不必要的 if。"
+    },
+    "DiagnosticCode.unreachable-code": {
+        "en": "Unreachable code",
+        "zh-CN": "不可达的代码。"
+    },
+    "DiagnosticCode.unused": {
+        "en": "Unused",
+        "zh-CN": "未使用的变量。"
+    },
+    "DiagnosticSeveritySetting.error": {
+        "en": "Represents an error diagnostic severity.",
+        "zh-CN": "诊断严重性: 错误。"
+    },
+    "DiagnosticSeveritySetting.hint": {
+        "en": "Represents a hint diagnostic severity.",
+        "zh-CN": "诊断严重性: 提示。"
+    },
+    "DiagnosticSeveritySetting.information": {
+        "en": "Represents an information diagnostic severity.",
+        "zh-CN": "诊断严重性: 信息。"
+    },
+    "DiagnosticSeveritySetting.warning": {
+        "en": "Represents a warning diagnostic severity.",
+        "zh-CN": "诊断严重性: 警告。"
+    },
+    "EmmyrcCodeAction.insertSpace": {
+        "en": "Add space after `---` comments when inserting `@diagnostic disable-next-line`.",
+        "zh-CN": "是否在 '---' 后插入空格。"
+    },
+    "EmmyrcCodeLens.enable": {
+        "en": "Enable code lens."
+    },
+    "EmmyrcCompletion": {
+        "en": "Configuration for EmmyLua code completion.",
+        "zh-CN": "EmmyLua 代码补全配置。"
+    },
+    "EmmyrcCompletion.autoRequire": {
+        "en": "Automatically insert call to `require` when autocompletion\ninserts objects from other modules.",
+        "zh-CN": "自动补全 require 语句。"
+    },
+    "EmmyrcCompletion.autoRequireFunction": {
+        "en": "The function used for auto-requiring modules.",
+        "zh-CN": "自动补全 require 语句时使用的函数名。"
+    },
+    "EmmyrcCompletion.autoRequireNamingConvention": {
+        "en": "The naming convention for auto-required filenames.",
+        "zh-CN": "自动补全 require 语句时使用的命名规范。"
+    },
+    "EmmyrcCompletion.autoRequireSeparator": {
+        "en": "A separator used in auto-require paths.",
+        "zh-CN": "自动补全 require 语句时使用的分隔符。"
+    },
+    "EmmyrcCompletion.baseFunctionIncludesName": {
+        "en": "Whether to include the name in the base function completion. Effect: `function () end` -> `function name() end`.",
+        "zh-CN": "是否在基本函数补全中包含函数名。效果: `function () end` -> `function name() end`。"
+    },
+    "EmmyrcCompletion.callSnippet": {
+        "en": "Whether to use call snippets in completions.",
+        "zh-CN": "是否使用代码片段补全函数调用。"
+    },
+    "EmmyrcCompletion.enable": {
+        "en": "Enable autocompletion.",
+        "zh-CN": "是否启用代码补全。"
+    },
+    "EmmyrcCompletion.postfix": {
+        "en": "Symbol that's used to trigger postfix autocompletion.",
+        "zh-CN": "后缀补全触发关键词。"
+    },
+    "EmmyrcDiagnostic": {
+        "en": "Represents the diagnostic configuration for Emmyrc.",
+        "zh-CN": "Emmyrc 诊断配置。"
+    },
+    "EmmyrcDiagnostic.diagnosticInterval": {
+        "en": "Delay between opening/changing a file and scanning it for errors, in milliseconds.",
+        "zh-CN": "诊断间隔时间(毫秒)。"
+    },
+    "EmmyrcDiagnostic.disable": {
+        "en": "A list of diagnostic codes that are disabled.",
+        "zh-CN": "禁用的诊断代码列表。"
+    },
+    "EmmyrcDiagnostic.enable": {
+        "en": "A flag indicating whether diagnostics are enabled.",
+        "zh-CN": "是否启用诊断。"
+    },
+    "EmmyrcDiagnostic.enables": {
+        "en": "A list of diagnostic codes that are enabled.",
+        "zh-CN": "启用的诊断代码列表。"
+    },
+    "EmmyrcDiagnostic.globals": {
+        "en": "A list of global variables.",
+        "zh-CN": "全局变量列表，在该列表中的全局变量不会被诊断为未定义。"
+    },
+    "EmmyrcDiagnostic.globalsRegex": {
+        "en": "A list of regular expressions for global variables.",
+        "zh-CN": "全局变量正则表达式列表，符合正则表达式的全局变量不会被诊断为未定义。"
+    },
+    "EmmyrcDiagnostic.severity": {
+        "en": "A map of diagnostic codes to their severity settings.",
+        "zh-CN": "诊断代码与严重性设置的映射。"
+    },
+    "EmmyrcDoc.knownTags": {
+        "en": "List of known documentation tags.",
+        "zh-CN": "已知文档标签列表。"
+    },
+    "EmmyrcDoc.privateName": {
+        "en": "Treat specific field names as private, e.g. `m_*` means `XXX.m_id` and `XXX.m_type` are private, witch can only be accessed in the class where the definition is located.",
+        "zh-CN": "将特定字段名视为私有，例如 `m_*` 表示 `XXX.m_id` 和 `XXX.m_type` 是私有字段，只能在定义所在的类中访问。"
+    },
+    "EmmyrcDoc.rstDefaultRole": {
+        "en": "When `syntax` is `Myst` or `Rst`, specifies default role used\nwith RST processor."
+    },
+    "EmmyrcDoc.rstPrimaryDomain": {
+        "en": "When `syntax` is `Myst` or `Rst`, specifies primary domain used\nwith RST processor."
+    },
+    "EmmyrcDoc.syntax": {
+        "en": "Syntax for highlighting documentation."
+    },
+    "EmmyrcDocumentColor.enable": {
+        "en": "Enable parsing strings for color tags and showing a color picker next to them.",
+        "zh-CN": "是否启用文档颜色。"
+    },
+    "EmmyrcExternalTool.args": {
+        "en": "The arguments to pass to the external tool."
+    },
+    "EmmyrcExternalTool.program": {
+        "en": "The command to run the external tool."
+    },
+    "EmmyrcFilenameConvention.camel-case": {
+        "en": "Convert the filename to camelCase.",
+        "zh-CN": "将文件名转换为驼峰(camelCase)命名。"
+    },
+    "EmmyrcFilenameConvention.keep": {
+        "en": "Keep the original filename.",
+        "zh-CN": "保持原始文件名。"
+    },
+    "EmmyrcFilenameConvention.keep-class": {
+        "en": "When returning class definition, use class name, otherwise keep original name.",
+        "zh-CN": "返回类定义时，使用类名，否则保持原始名称。"
+    },
+    "EmmyrcFilenameConvention.pascal-case": {
+        "en": "Convert the filename to PascalCase.",
+        "zh-CN": "将文件名转换为帕斯卡(PascalCase)命名。"
+    },
+    "EmmyrcFilenameConvention.snake-case": {
+        "en": "Convert the filename to snake_case.",
+        "zh-CN": "将文件名转换为蛇形(snake_case)命名。"
+    },
+    "EmmyrcHover.enable": {
+        "en": "Enable showing documentation on hover.",
+        "zh-CN": "是否启用悬浮提示。"
+    },
+    "EmmyrcInlayHint.enable": {
+        "en": "Enable inlay hints.",
+        "zh-CN": "是否启用内联提示。"
+    },
+    "EmmyrcInlayHint.enumParamHint": {
+        "en": "Show name of enumerator when passing a literal value to a function\nthat expects an enum.\n\nExample:\n\n```lua\n--- @enum Level\nlocal Foo = {\n   Info = 1,\n   Error = 2,\n}\n\n--- @param l Level\nfunction print_level(l) end\n\nprint_level(1 --[[ Hint: Level.Info ]])\n```",
+        "zh-CN": "是否启用枚举参数提示。"
+    },
+    "EmmyrcInlayHint.indexHint": {
+        "en": "Show named array indexes.\n\nExample:\n\n```lua\nlocal array = {\n   [1] = 1, -- [name]\n}\n\nprint(array[1] --[[ Hint: name ]])\n```",
+        "zh-CN": "在索引表达式跨行时，显示提示。"
+    },
+    "EmmyrcInlayHint.localHint": {
+        "en": "Show types of local variables.",
+        "zh-CN": "是否启用局部变量提示。"
+    },
+    "EmmyrcInlayHint.metaCallHint": {
+        "en": "Show hint when calling an object results in a call to\nits meta table's `__call` function.",
+        "zh-CN": "是否启用 `__call` 调用提示。"
+    },
+    "EmmyrcInlayHint.overrideHint": {
+        "en": "Show methods that override functions from base class.",
+        "zh-CN": "是否启用重写提示。"
+    },
+    "EmmyrcInlayHint.paramHint": {
+        "en": "Show parameter names in function calls and parameter types in function definitions.",
+        "zh-CN": "是否启用参数提示。"
+    },
+    "EmmyrcInlineValues.enable": {
+        "en": "Show inline values during debug.",
+        "zh-CN": "是否启用内联值。用于在调试断点时显示变量值。"
+    },
+    "EmmyrcLuaVersion.Lua5.1": {
+        "en": "Lua 5.1"
+    },
+    "EmmyrcLuaVersion.Lua5.2": {
+        "en": "Lua 5.2"
+    },
+    "EmmyrcLuaVersion.Lua5.3": {
+        "en": "Lua 5.3"
+    },
+    "EmmyrcLuaVersion.Lua5.4": {
+        "en": "Lua 5.4"
+    },
+    "EmmyrcLuaVersion.Lua5.5": {
+        "en": "Lua 5.5"
+    },
+    "EmmyrcLuaVersion.LuaJIT": {
+        "en": "LuaJIT"
+    },
+    "EmmyrcLuaVersion.LuaLatest": {
+        "en": "Lua Latest"
+    },
+    "EmmyrcReference.enable": {
+        "en": "Enable searching for symbol usages.",
+        "zh-CN": "是否启用引用搜索。"
+    },
+    "EmmyrcReference.fuzzySearch": {
+        "en": "Use fuzzy search when searching for symbol usages\nand normal search didn't find anything.",
+        "zh-CN": "是否启用模糊搜索。"
+    },
+    "EmmyrcReference.shortStringSearch": {
+        "en": "Also search for usages in strings.",
+        "zh-CN": "缓存短字符串用于搜索。"
+    },
+    "EmmyrcReformat.externalTool": {
+        "en": "Whether to enable internal code reformatting."
+    },
+    "EmmyrcReformat.useDiff": {
+        "en": "Whether to use the diff algorithm for formatting."
+    },
+    "EmmyrcRuntime.classDefaultCall": {
+        "en": "class default overload function.",
+        "zh-CN": "类默认重载函数。"
+    },
+    "EmmyrcRuntime.extensions": {
+        "en": "file Extensions. eg: .lua, .lua.txt",
+        "zh-CN": "文件扩展名。例如：.lua, .lua.txt"
+    },
+    "EmmyrcRuntime.frameworkVersions": {
+        "en": "Framework versions.",
+        "zh-CN": "框架版本列表。"
+    },
+    "EmmyrcRuntime.nonstandardSymbol": {
+        "en": "Non-standard symbols."
+    },
+    "EmmyrcRuntime.requireLikeFunction": {
+        "en": "Functions that like require.",
+        "zh-CN": "类似 require 的函数列表。"
+    },
+    "EmmyrcRuntime.requirePattern": {
+        "en": "Require pattern. eg. \"?.lua\", \"?/init.lua\"",
+        "zh-CN": "require 模式。例如：\"?.lua\", \"?/init.lua\""
+    },
+    "EmmyrcRuntime.version": {
+        "en": "Lua version.",
+        "zh-CN": "Lua 版本。"
+    },
+    "EmmyrcSemanticToken.enable": {
+        "en": "Enable semantic tokens.",
+        "zh-CN": "是否启用语义标记。"
+    },
+    "EmmyrcSemanticToken.renderDocumentationMarkup": {
+        "en": "Render Markdown/RST in documentation. Set `doc.syntax` for this option to have effect."
+    },
+    "EmmyrcSignature.detailSignatureHelper": {
+        "en": "Whether to enable signature help.",
+        "zh-CN": "是否启用签名帮助。"
+    },
+    "EmmyrcStrict.arrayIndex": {
+        "en": "Whether to enable strict mode array indexing.",
+        "zh-CN": "是否启用严格模式数组索引，严格模式下数组取值返回将包含 nil。"
+    },
+    "EmmyrcStrict.docBaseConstMatchBaseType": {
+        "en": "Base constant types defined in doc can match base types, allowing int to match `---@alias id 1|2|3`, same for string.",
+        "zh-CN": "doc定义的基础常量类型可以匹配基础类型，使 int 可以匹配 `---@alias id 1|2|3`，string 同理。"
+    },
+    "EmmyrcStrict.metaOverrideFileDefine": {
+        "en": "meta define overrides file define",
+        "zh-CN": "`---@meta`文件的定义完全覆盖真实文件的定义。"
+    },
+    "EmmyrcStrict.requirePath": {
+        "en": "Whether to enable strict mode require path.",
+        "zh-CN": "是否启用严格模式 require 路径。严格模式时 require 必须从指定的根目录开始。"
+    },
+    "EmmyrcWorkspace.enableReindex": {
+        "en": "Enable full project reindex after changing a file.",
+        "zh-CN": "启用重新索引。"
+    },
+    "EmmyrcWorkspace.encoding": {
+        "en": "Encoding. eg: \"utf-8\"",
+        "zh-CN": "编码。例如：\"utf-8\""
+    },
+    "EmmyrcWorkspace.ignoreDir": {
+        "en": "Ignore directories.",
+        "zh-CN": "忽略的目录。"
+    },
+    "EmmyrcWorkspace.ignoreGlobs": {
+        "en": "Ignore globs. eg: [\"**/*.lua\"]",
+        "zh-CN": "忽略的文件。例如：[\"**/*.lua\"]"
+    },
+    "EmmyrcWorkspace.library": {
+        "en": "Library paths. eg: \"/usr/local/share/lua/5.1\"",
+        "zh-CN": "库路径。例如：\"/usr/local/share/lua/5.1\""
+    },
+    "EmmyrcWorkspace.moduleMap": {
+        "en": "Module map. key is regex, value is new module regex\neg: {\n    \"^(.*)$\": \"module_$1\"\n    \"^lib(.*)$\": \"script$1\"\n}",
+        "zh-CN": "模块映射列表。key 是正则表达式，value 是新的模块正则表达式\n 例如：{\n    \"^(.*)$\": \"module_$1\"\n    \"^lib(.*)$\": \"script$1\"\n}"
+    },
+    "EmmyrcWorkspace.reindexDuration": {
+        "en": "Delay between changing a file and full project reindex, in milliseconds.",
+        "zh-CN": "当保存文件时，ls 将在指定毫秒后重新索引工作区。"
+    },
+    "EmmyrcWorkspace.workspaceRoots": {
+        "en": "Workspace roots. eg: [\"src\", \"test\"]",
+        "zh-CN": "工作区根目录列表。例如：[\"src\", \"test\"]"
+    }
 }

--- a/syntaxes/schema.zh-cn.json
+++ b/syntaxes/schema.zh-cn.json
@@ -1,978 +1,1100 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Emmyrc",
-  "type": "object",
-  "properties": {
-    "$schema": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "codeAction": {
-      "$ref": "#/$defs/EmmyrcCodeAction",
-      "default": {
-        "insertSpace": false
-      }
-    },
-    "codeLens": {
-      "$ref": "#/$defs/EmmyrcCodeLens",
-      "default": {
-        "enable": true
-      }
-    },
-    "completion": {
-      "$ref": "#/$defs/EmmyrcCompletion",
-      "default": {
-        "autoRequire": true,
-        "autoRequireFunction": "require",
-        "autoRequireNamingConvention": "keep",
-        "autoRequireSeparator": ".",
-        "baseFunctionIncludesName": true,
-        "callSnippet": false,
-        "enable": true,
-        "postfix": "@"
-      }
-    },
-    "diagnostics": {
-      "$ref": "#/$defs/EmmyrcDiagnostic",
-      "default": {
-        "diagnosticInterval": 500,
-        "disable": [],
-        "enable": true,
-        "enables": [],
-        "globals": [],
-        "globalsRegex": [],
-        "severity": {}
-      }
-    },
-    "doc": {
-      "$ref": "#/$defs/EmmyrcDoc",
-      "default": {
-        "knownTags": [],
-        "privateName": []
-      }
-    },
-    "documentColor": {
-      "$ref": "#/$defs/EmmyrcDocumentColor",
-      "default": {
-        "enable": true
-      }
-    },
-    "hint": {
-      "$ref": "#/$defs/EmmyrcInlayHint",
-      "default": {
-        "enable": true,
-        "enumParamHint": false,
-        "indexHint": true,
-        "localHint": true,
-        "metaCallHint": true,
-        "overrideHint": true,
-        "paramHint": true
-      }
-    },
-    "hover": {
-      "$ref": "#/$defs/EmmyrcHover",
-      "default": {
-        "enable": true
-      }
-    },
-    "inlineValues": {
-      "$ref": "#/$defs/EmmyrcInlineValues",
-      "default": {
-        "enable": true
-      }
-    },
-    "references": {
-      "$ref": "#/$defs/EmmyrcReference",
-      "default": {
-        "enable": true,
-        "fuzzySearch": true,
-        "shortStringSearch": false
-      }
-    },
-    "resource": {
-      "$ref": "#/$defs/EmmyrcResource",
-      "default": {
-        "paths": []
-      }
-    },
-    "runtime": {
-      "$ref": "#/$defs/EmmyrcRuntime",
-      "default": {
-        "classDefaultCall": {
-          "forceNonColon": false,
-          "forceReturnSelf": false,
-          "functionName": ""
-        },
-        "extensions": [],
-        "frameworkVersions": [],
-        "requireLikeFunction": [],
-        "requirePattern": [],
-        "version": "LuaLatest"
-      }
-    },
-    "semanticTokens": {
-      "$ref": "#/$defs/EmmyrcSemanticToken",
-      "default": {
-        "enable": true
-      }
-    },
-    "signature": {
-      "$ref": "#/$defs/EmmyrcSignature",
-      "default": {
-        "detailSignatureHelper": true
-      }
-    },
-    "strict": {
-      "$ref": "#/$defs/EmmyrcStrict",
-      "default": {
-        "arrayIndex": true,
-        "docBaseConstMatchBaseType": true,
-        "metaOverrideFileDefine": true,
-        "requirePath": false,
-        "typeCall": false
-      }
-    },
-    "workspace": {
-      "$ref": "#/$defs/EmmyrcWorkspace",
-      "default": {
-        "enableReindex": false,
-        "encoding": "utf-8",
-        "ignoreDir": [],
-        "ignoreGlobs": [],
-        "library": [],
-        "moduleMap": [],
-        "preloadFileSize": 0,
-        "reindexDuration": 5000,
-        "workspaceRoots": []
-      }
-    }
-  },
-  "$defs": {
-    "ClassDefaultCall": {
-      "type": "object",
-      "properties": {
-        "forceNonColon": {
-          "description": "强制非冒号定义。当 `function_name` 不为空时生效。",
-          "type": "boolean",
-          "default": true
-        },
-        "forceReturnSelf": {
-          "description": "强制返回 `self`。",
-          "type": "boolean",
-          "default": true
-        },
-        "functionName": {
-          "description": "类默认重载函数。例如：\"__init\"。",
-          "type": "string",
-          "default": ""
-        }
-      }
-    },
-    "DiagnosticCode": {
-      "oneOf": [
-        {
-          "type": "string",
-          "enum": [
-            "none"
-          ]
-        },
-        {
-          "description": "语法错误。",
-          "type": "string",
-          "const": "syntax-error"
-        },
-        {
-          "description": "注解语法错误。",
-          "type": "string",
-          "const": "doc-syntax-error"
-        },
-        {
-          "description": "类型未找到。",
-          "type": "string",
-          "const": "type-not-found"
-        },
-        {
-          "description": "缺少返回语句。",
-          "type": "string",
-          "const": "missing-return"
-        },
-        {
-          "description": "参数类型不匹配。",
-          "type": "string",
-          "const": "param-type-not-match"
-        },
-        {
-          "description": "缺少参数。",
-          "type": "string",
-          "const": "missing-parameter"
-        },
-        {
-          "description": "冗余参数。",
-          "type": "string",
-          "const": "redundant-parameter"
-        },
-        {
-          "description": "不可达的代码。",
-          "type": "string",
-          "const": "unreachable-code"
-        },
-        {
-          "description": "未使用的变量。",
-          "type": "string",
-          "const": "unused"
-        },
-        {
-          "description": "未定义的全局变量。",
-          "type": "string",
-          "const": "undefined-global"
-        },
-        {
-          "description": "已弃用。",
-          "type": "string",
-          "const": "deprecated"
-        },
-        {
-          "description": "成员可见性检查。",
-          "type": "string",
-          "const": "access-invisible"
-        },
-        {
-          "description": "不可丢弃返回值。",
-          "type": "string",
-          "const": "discard-returns"
-        },
-        {
-          "description": "未定义的字段。",
-          "type": "string",
-          "const": "undefined-field"
-        },
-        {
-          "description": "局部常量重新赋值。",
-          "type": "string",
-          "const": "local-const-reassign"
-        },
-        {
-          "description": "迭代变量重新赋值。",
-          "type": "string",
-          "const": "iter-variable-reassign"
-        },
-        {
-          "description": "重复定义的类型。",
-          "type": "string",
-          "const": "duplicate-type"
-        },
-        {
-          "description": "重复定义的局部变量。",
-          "type": "string",
-          "const": "redefined-local"
-        },
-        {
-          "description": "重复定义的标签。",
-          "type": "string",
-          "const": "redefined-label"
-        },
-        {
-          "description": "代码风格检查。",
-          "type": "string",
-          "const": "code-style-check"
-        },
-        {
-          "description": "需要检查 nil。",
-          "type": "string",
-          "const": "need-check-nil"
-        },
-        {
-          "description": "在同步上下文中使用 await。",
-          "type": "string",
-          "const": "await-in-sync"
-        },
-        {
-          "description": "注解使用错误。",
-          "type": "string",
-          "const": "annotation-usage-error"
-        },
-        {
-          "description": "返回类型不匹配。",
-          "type": "string",
-          "const": "return-type-mismatch"
-        },
-        {
-          "description": "缺少返回值。",
-          "type": "string",
-          "const": "missing-return-value"
-        },
-        {
-          "description": "冗余的返回值。",
-          "type": "string",
-          "const": "redundant-return-value"
-        },
-        {
-          "description": "未使用注解定义的参数。",
-          "type": "string",
-          "const": "undefined-doc-param"
-        },
-        {
-          "description": "重复定义的字段(注解)。",
-          "type": "string",
-          "const": "duplicate-doc-field"
-        },
-        {
-          "description": "未知文档注解。",
-          "type": "string",
-          "const": "unknown-doc-tag"
-        },
-        {
-          "description": "缺少字段。",
-          "type": "string",
-          "const": "missing-fields"
-        },
-        {
-          "description": "注入字段。",
-          "type": "string",
-          "const": "inject-field"
-        },
-        {
-          "description": "类型循环依赖。",
-          "type": "string",
-          "const": "circle-doc-class"
-        },
-        {
-          "description": "不完整的签名文档。",
-          "type": "string",
-          "const": "incomplete-signature-doc"
-        },
-        {
-          "description": "全局变量缺少文档。",
-          "type": "string",
-          "const": "missing-global-doc"
-        },
-        {
-          "description": "赋值类型不匹配。",
-          "type": "string",
-          "const": "assign-type-mismatch"
-        },
-        {
-          "description": "重复的 require 导入。",
-          "type": "string",
-          "const": "duplicate-require"
-        },
-        {
-          "description": "在 assert 中使用了非字面量表达式。",
-          "type": "string",
-          "const": "non-literal-expressions-in-assert"
-        },
-        {
-          "description": "不平衡的赋值。",
-          "type": "string",
-          "const": "unbalanced-assignments"
-        },
-        {
-          "description": "不必要的 assert。",
-          "type": "string",
-          "const": "unnecessary-assert"
-        },
-        {
-          "description": "不必要的 if。",
-          "type": "string",
-          "const": "unnecessary-if"
-        },
-        {
-          "description": "重复定义的字段(实际代码)。",
-          "type": "string",
-          "const": "duplicate-set-field"
-        },
-        {
-          "description": "重复的索引。",
-          "type": "string",
-          "const": "duplicate-index"
-        },
-        {
-          "description": "泛型约束不匹配。",
-          "type": "string",
-          "const": "generic-constraint-mismatch"
-        },
-        {
-          "description": "cast-type-mismatch",
-          "type": "string",
-          "const": "cast-type-mismatch"
-        },
-        {
-          "description": "require 模块不可见。",
-          "type": "string",
-          "const": "require-module-not-visible"
-        },
-        {
-          "description": "枚举值不匹配。",
-          "type": "string",
-          "const": "enum-value-mismatch"
-        }
-      ]
-    },
-    "DiagnosticSeveritySetting": {
-      "oneOf": [
-        {
-          "description": "诊断严重性: 错误。",
-          "type": "string",
-          "const": "error"
-        },
-        {
-          "description": "诊断严重性: 警告。",
-          "type": "string",
-          "const": "warning"
-        },
-        {
-          "description": "诊断严重性: 信息。",
-          "type": "string",
-          "const": "information"
-        },
-        {
-          "description": "诊断严重性: 提示。",
-          "type": "string",
-          "const": "hint"
-        }
-      ]
-    },
-    "EmmyrcCodeAction": {
-      "type": "object",
-      "properties": {
-        "insertSpace": {
-          "description": "是否在 '---' 后插入空格。",
-          "type": "boolean",
-          "default": false,
-          "x-vscode-setting": true
-        }
-      }
-    },
-    "EmmyrcCodeLens": {
-      "type": "object",
-      "properties": {
-        "enable": {
-          "description": "Enable code lens.",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        }
-      }
-    },
-    "EmmyrcCompletion": {
-      "description": "EmmyLua 代码补全配置。",
-      "type": "object",
-      "properties": {
-        "autoRequire": {
-          "description": "自动补全 require 语句。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        },
-        "autoRequireFunction": {
-          "description": "自动补全 require 语句时使用的函数名。",
-          "type": "string",
-          "default": "require"
-        },
-        "autoRequireNamingConvention": {
-          "description": "自动补全 require 语句时使用的命名规范。",
-          "$ref": "#/$defs/EmmyrcFilenameConvention",
-          "default": "keep"
-        },
-        "autoRequireSeparator": {
-          "description": "自动补全 require 语句时使用的分隔符。",
-          "type": "string",
-          "default": "."
-        },
-        "baseFunctionIncludesName": {
-          "description": "是否在基本函数补全中包含函数名。效果: `function () end` -> `function name() end`。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        },
-        "callSnippet": {
-          "description": "是否使用代码片段补全函数调用。",
-          "type": "boolean",
-          "default": false
-        },
-        "enable": {
-          "description": "是否启用代码补全。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        },
-        "postfix": {
-          "description": "后缀补全触发关键词。",
-          "type": "string",
-          "default": "@",
-          "x-vscode-setting": {
-            "default": null,
-            "enum": [
-              null,
-              "@",
-              ".",
-              ":"
-            ],
-            "enumItemLabels": [
-              "Default"
-            ],
-            "markdownEnumDescriptions": [
-              "%config.common.enum.default.description%"
-            ],
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Emmyrc",
+    "type": "object",
+    "properties": {
+        "$schema": {
             "type": [
-              "string",
-              "null"
+                "string",
+                "null"
             ]
-          }
+        },
+        "codeAction": {
+            "$ref": "#/$defs/EmmyrcCodeAction",
+            "default": {
+                "insertSpace": false
+            }
+        },
+        "codeLens": {
+            "$ref": "#/$defs/EmmyrcCodeLens",
+            "default": {
+                "enable": true
+            }
+        },
+        "completion": {
+            "$ref": "#/$defs/EmmyrcCompletion",
+            "default": {
+                "autoRequire": true,
+                "autoRequireFunction": "require",
+                "autoRequireNamingConvention": "keep",
+                "autoRequireSeparator": ".",
+                "baseFunctionIncludesName": true,
+                "callSnippet": false,
+                "enable": true,
+                "postfix": "@"
+            }
+        },
+        "diagnostics": {
+            "$ref": "#/$defs/EmmyrcDiagnostic",
+            "default": {
+                "diagnosticInterval": 500,
+                "disable": [],
+                "enable": true,
+                "enables": [],
+                "globals": [],
+                "globalsRegex": [],
+                "severity": {}
+            }
+        },
+        "doc": {
+            "$ref": "#/$defs/EmmyrcDoc",
+            "default": {
+                "knownTags": [],
+                "privateName": [],
+                "syntax": "none"
+            }
+        },
+        "documentColor": {
+            "$ref": "#/$defs/EmmyrcDocumentColor",
+            "default": {
+                "enable": true
+            }
+        },
+        "format": {
+            "$ref": "#/$defs/EmmyrcReformat",
+            "default": {
+                "externalTool": null,
+                "useDiff": false
+            }
+        },
+        "hint": {
+            "$ref": "#/$defs/EmmyrcInlayHint",
+            "default": {
+                "enable": true,
+                "enumParamHint": false,
+                "indexHint": true,
+                "localHint": true,
+                "metaCallHint": true,
+                "overrideHint": true,
+                "paramHint": true
+            }
+        },
+        "hover": {
+            "$ref": "#/$defs/EmmyrcHover",
+            "default": {
+                "enable": true
+            }
+        },
+        "inlineValues": {
+            "$ref": "#/$defs/EmmyrcInlineValues",
+            "default": {
+                "enable": true
+            }
+        },
+        "references": {
+            "$ref": "#/$defs/EmmyrcReference",
+            "default": {
+                "enable": true,
+                "fuzzySearch": true,
+                "shortStringSearch": false
+            }
+        },
+        "resource": {
+            "$ref": "#/$defs/EmmyrcResource",
+            "default": {
+                "paths": []
+            }
+        },
+        "runtime": {
+            "$ref": "#/$defs/EmmyrcRuntime",
+            "default": {
+                "classDefaultCall": {
+                    "forceNonColon": false,
+                    "forceReturnSelf": false,
+                    "functionName": ""
+                },
+                "extensions": [],
+                "frameworkVersions": [],
+                "nonstandardSymbol": [],
+                "requireLikeFunction": [],
+                "requirePattern": [],
+                "version": "LuaLatest"
+            }
+        },
+        "semanticTokens": {
+            "$ref": "#/$defs/EmmyrcSemanticToken",
+            "default": {
+                "enable": true,
+                "renderDocumentationMarkup": false
+            }
+        },
+        "signature": {
+            "$ref": "#/$defs/EmmyrcSignature",
+            "default": {
+                "detailSignatureHelper": true
+            }
+        },
+        "strict": {
+            "$ref": "#/$defs/EmmyrcStrict",
+            "default": {
+                "arrayIndex": true,
+                "docBaseConstMatchBaseType": true,
+                "metaOverrideFileDefine": true,
+                "requirePath": false,
+                "typeCall": false
+            }
+        },
+        "workspace": {
+            "$ref": "#/$defs/EmmyrcWorkspace",
+            "default": {
+                "enableReindex": false,
+                "encoding": "utf-8",
+                "ignoreDir": [],
+                "ignoreGlobs": [],
+                "library": [],
+                "moduleMap": [],
+                "preloadFileSize": 0,
+                "reindexDuration": 5000,
+                "workspaceRoots": []
+            }
         }
-      }
     },
-    "EmmyrcDiagnostic": {
-      "description": "Emmyrc 诊断配置。",
-      "type": "object",
-      "properties": {
-        "diagnosticInterval": {
-          "description": "诊断间隔时间(毫秒)。",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0,
-          "x-vscode-setting": true
+    "$defs": {
+        "ClassDefaultCall": {
+            "type": "object",
+            "properties": {
+                "forceNonColon": {
+                    "description": "强制非冒号定义。当 `function_name` 不为空时生效。",
+                    "type": "boolean",
+                    "default": true
+                },
+                "forceReturnSelf": {
+                    "description": "强制返回 `self`。",
+                    "type": "boolean",
+                    "default": true
+                },
+                "functionName": {
+                    "description": "类默认重载函数。例如：\"__init\"。",
+                    "type": "string",
+                    "default": ""
+                }
+            }
         },
-        "disable": {
-          "description": "禁用的诊断代码列表。",
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/DiagnosticCode"
-          }
+        "DiagnosticCode": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "enum": [
+                        "none"
+                    ]
+                },
+                {
+                    "description": "语法错误。",
+                    "type": "string",
+                    "const": "syntax-error"
+                },
+                {
+                    "description": "注解语法错误。",
+                    "type": "string",
+                    "const": "doc-syntax-error"
+                },
+                {
+                    "description": "类型未找到。",
+                    "type": "string",
+                    "const": "type-not-found"
+                },
+                {
+                    "description": "缺少返回语句。",
+                    "type": "string",
+                    "const": "missing-return"
+                },
+                {
+                    "description": "参数类型不匹配。",
+                    "type": "string",
+                    "const": "param-type-not-match"
+                },
+                {
+                    "description": "缺少参数。",
+                    "type": "string",
+                    "const": "missing-parameter"
+                },
+                {
+                    "description": "冗余参数。",
+                    "type": "string",
+                    "const": "redundant-parameter"
+                },
+                {
+                    "description": "不可达的代码。",
+                    "type": "string",
+                    "const": "unreachable-code"
+                },
+                {
+                    "description": "未使用的变量。",
+                    "type": "string",
+                    "const": "unused"
+                },
+                {
+                    "description": "未定义的全局变量。",
+                    "type": "string",
+                    "const": "undefined-global"
+                },
+                {
+                    "description": "已弃用。",
+                    "type": "string",
+                    "const": "deprecated"
+                },
+                {
+                    "description": "成员可见性检查。",
+                    "type": "string",
+                    "const": "access-invisible"
+                },
+                {
+                    "description": "不可丢弃返回值。",
+                    "type": "string",
+                    "const": "discard-returns"
+                },
+                {
+                    "description": "未定义的字段。",
+                    "type": "string",
+                    "const": "undefined-field"
+                },
+                {
+                    "description": "局部常量重新赋值。",
+                    "type": "string",
+                    "const": "local-const-reassign"
+                },
+                {
+                    "description": "迭代变量重新赋值。",
+                    "type": "string",
+                    "const": "iter-variable-reassign"
+                },
+                {
+                    "description": "重复定义的类型。",
+                    "type": "string",
+                    "const": "duplicate-type"
+                },
+                {
+                    "description": "重复定义的局部变量。",
+                    "type": "string",
+                    "const": "redefined-local"
+                },
+                {
+                    "description": "重复定义的标签。",
+                    "type": "string",
+                    "const": "redefined-label"
+                },
+                {
+                    "description": "代码风格检查。",
+                    "type": "string",
+                    "const": "code-style-check"
+                },
+                {
+                    "description": "需要检查 nil。",
+                    "type": "string",
+                    "const": "need-check-nil"
+                },
+                {
+                    "description": "在同步上下文中使用 await。",
+                    "type": "string",
+                    "const": "await-in-sync"
+                },
+                {
+                    "description": "注解使用错误。",
+                    "type": "string",
+                    "const": "annotation-usage-error"
+                },
+                {
+                    "description": "返回类型不匹配。",
+                    "type": "string",
+                    "const": "return-type-mismatch"
+                },
+                {
+                    "description": "缺少返回值。",
+                    "type": "string",
+                    "const": "missing-return-value"
+                },
+                {
+                    "description": "冗余的返回值。",
+                    "type": "string",
+                    "const": "redundant-return-value"
+                },
+                {
+                    "description": "未使用注解定义的参数。",
+                    "type": "string",
+                    "const": "undefined-doc-param"
+                },
+                {
+                    "description": "重复定义的字段(注解)。",
+                    "type": "string",
+                    "const": "duplicate-doc-field"
+                },
+                {
+                    "description": "未知文档注解。",
+                    "type": "string",
+                    "const": "unknown-doc-tag"
+                },
+                {
+                    "description": "缺少字段。",
+                    "type": "string",
+                    "const": "missing-fields"
+                },
+                {
+                    "description": "注入字段。",
+                    "type": "string",
+                    "const": "inject-field"
+                },
+                {
+                    "description": "类型循环依赖。",
+                    "type": "string",
+                    "const": "circle-doc-class"
+                },
+                {
+                    "description": "不完整的签名文档。",
+                    "type": "string",
+                    "const": "incomplete-signature-doc"
+                },
+                {
+                    "description": "全局变量缺少文档。",
+                    "type": "string",
+                    "const": "missing-global-doc"
+                },
+                {
+                    "description": "赋值类型不匹配。",
+                    "type": "string",
+                    "const": "assign-type-mismatch"
+                },
+                {
+                    "description": "重复的 require 导入。",
+                    "type": "string",
+                    "const": "duplicate-require"
+                },
+                {
+                    "description": "在 assert 中使用了非字面量表达式。",
+                    "type": "string",
+                    "const": "non-literal-expressions-in-assert"
+                },
+                {
+                    "description": "不平衡的赋值。",
+                    "type": "string",
+                    "const": "unbalanced-assignments"
+                },
+                {
+                    "description": "不必要的 assert。",
+                    "type": "string",
+                    "const": "unnecessary-assert"
+                },
+                {
+                    "description": "不必要的 if。",
+                    "type": "string",
+                    "const": "unnecessary-if"
+                },
+                {
+                    "description": "重复定义的字段(实际代码)。",
+                    "type": "string",
+                    "const": "duplicate-set-field"
+                },
+                {
+                    "description": "重复的索引。",
+                    "type": "string",
+                    "const": "duplicate-index"
+                },
+                {
+                    "description": "泛型约束不匹配。",
+                    "type": "string",
+                    "const": "generic-constraint-mismatch"
+                },
+                {
+                    "description": "cast-type-mismatch",
+                    "type": "string",
+                    "const": "cast-type-mismatch"
+                },
+                {
+                    "description": "require 模块不可见。",
+                    "type": "string",
+                    "const": "require-module-not-visible"
+                },
+                {
+                    "description": "枚举值不匹配。",
+                    "type": "string",
+                    "const": "enum-value-mismatch"
+                }
+            ]
         },
-        "enable": {
-          "description": "是否启用诊断。",
-          "type": "boolean",
-          "default": true
+        "DiagnosticSeveritySetting": {
+            "oneOf": [
+                {
+                    "description": "诊断严重性: 错误。",
+                    "type": "string",
+                    "const": "error"
+                },
+                {
+                    "description": "诊断严重性: 警告。",
+                    "type": "string",
+                    "const": "warning"
+                },
+                {
+                    "description": "诊断严重性: 信息。",
+                    "type": "string",
+                    "const": "information"
+                },
+                {
+                    "description": "诊断严重性: 提示。",
+                    "type": "string",
+                    "const": "hint"
+                }
+            ]
         },
-        "enables": {
-          "description": "启用的诊断代码列表。",
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/DiagnosticCode"
-          }
+        "DocSyntax": {
+            "type": "string",
+            "enum": [
+                "none",
+                "md",
+                "myst",
+                "rst"
+            ]
         },
-        "globals": {
-          "description": "全局变量列表，在该列表中的全局变量不会被诊断为未定义。",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
+        "EmmyrcCodeAction": {
+            "type": "object",
+            "properties": {
+                "insertSpace": {
+                    "description": "是否在 '---' 后插入空格。",
+                    "type": "boolean",
+                    "default": false,
+                    "x-vscode-setting": true
+                }
+            }
         },
-        "globalsRegex": {
-          "description": "全局变量正则表达式列表，符合正则表达式的全局变量不会被诊断为未定义。",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
+        "EmmyrcCodeLens": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "description": "Enable code lens.",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                }
+            }
         },
-        "severity": {
-          "description": "诊断代码与严重性设置的映射。",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/DiagnosticSeveritySetting"
-          },
-          "default": {}
+        "EmmyrcCompletion": {
+            "description": "EmmyLua 代码补全配置。",
+            "type": "object",
+            "properties": {
+                "autoRequire": {
+                    "description": "自动补全 require 语句。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                },
+                "autoRequireFunction": {
+                    "description": "自动补全 require 语句时使用的函数名。",
+                    "type": "string",
+                    "default": "require"
+                },
+                "autoRequireNamingConvention": {
+                    "description": "自动补全 require 语句时使用的命名规范。",
+                    "$ref": "#/$defs/EmmyrcFilenameConvention",
+                    "default": "keep"
+                },
+                "autoRequireSeparator": {
+                    "description": "自动补全 require 语句时使用的分隔符。",
+                    "type": "string",
+                    "default": "."
+                },
+                "baseFunctionIncludesName": {
+                    "description": "是否在基本函数补全中包含函数名。效果: `function () end` -> `function name() end`。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                },
+                "callSnippet": {
+                    "description": "是否使用代码片段补全函数调用。",
+                    "type": "boolean",
+                    "default": false
+                },
+                "enable": {
+                    "description": "是否启用代码补全。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                },
+                "postfix": {
+                    "description": "后缀补全触发关键词。",
+                    "type": "string",
+                    "default": "@",
+                    "x-vscode-setting": {
+                        "default": null,
+                        "enum": [
+                            null,
+                            "@",
+                            ".",
+                            ":"
+                        ],
+                        "enumItemLabels": [
+                            "Default"
+                        ],
+                        "markdownEnumDescriptions": [
+                            "%config.common.enum.default.description%"
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            }
+        },
+        "EmmyrcDiagnostic": {
+            "description": "Emmyrc 诊断配置。",
+            "type": "object",
+            "properties": {
+                "diagnosticInterval": {
+                    "description": "诊断间隔时间(毫秒)。",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "format": "uint64",
+                    "minimum": 0,
+                    "x-vscode-setting": true
+                },
+                "disable": {
+                    "description": "禁用的诊断代码列表。",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "$ref": "#/$defs/DiagnosticCode"
+                    }
+                },
+                "enable": {
+                    "description": "是否启用诊断。",
+                    "type": "boolean",
+                    "default": true
+                },
+                "enables": {
+                    "description": "启用的诊断代码列表。",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "$ref": "#/$defs/DiagnosticCode"
+                    }
+                },
+                "globals": {
+                    "description": "全局变量列表，在该列表中的全局变量不会被诊断为未定义。",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "globalsRegex": {
+                    "description": "全局变量正则表达式列表，符合正则表达式的全局变量不会被诊断为未定义。",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "severity": {
+                    "description": "诊断代码与严重性设置的映射。",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/DiagnosticSeveritySetting"
+                    },
+                    "default": {}
+                }
+            }
+        },
+        "EmmyrcDoc": {
+            "type": "object",
+            "properties": {
+                "knownTags": {
+                    "description": "已知文档标签列表。",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "privateName": {
+                    "description": "将特定字段名视为私有，例如 `m_*` 表示 `XXX.m_id` 和 `XXX.m_type` 是私有字段，只能在定义所在的类中访问。",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "rstDefaultRole": {
+                    "description": "When `syntax` is `Myst` or `Rst`, specifies default role used\nwith RST processor.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "rstPrimaryDomain": {
+                    "description": "When `syntax` is `Myst` or `Rst`, specifies primary domain used\nwith RST processor.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "syntax": {
+                    "description": "Syntax for highlighting documentation.",
+                    "$ref": "#/$defs/DocSyntax",
+                    "default": "none"
+                }
+            }
+        },
+        "EmmyrcDocumentColor": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "description": "是否启用文档颜色。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                }
+            }
+        },
+        "EmmyrcExternalTool": {
+            "type": "object",
+            "properties": {
+                "args": {
+                    "description": "The arguments to pass to the external tool.",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "program": {
+                    "description": "The command to run the external tool.",
+                    "type": "string",
+                    "default": ""
+                },
+                "timeout": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "default": 5000,
+                    "minimum": 0
+                }
+            }
+        },
+        "EmmyrcFilenameConvention": {
+            "oneOf": [
+                {
+                    "description": "保持原始文件名。",
+                    "type": "string",
+                    "const": "keep"
+                },
+                {
+                    "description": "将文件名转换为蛇形(snake_case)命名。",
+                    "type": "string",
+                    "const": "snake-case"
+                },
+                {
+                    "description": "将文件名转换为帕斯卡(PascalCase)命名。",
+                    "type": "string",
+                    "const": "pascal-case"
+                },
+                {
+                    "description": "将文件名转换为驼峰(camelCase)命名。",
+                    "type": "string",
+                    "const": "camel-case"
+                },
+                {
+                    "description": "返回类定义时，使用类名，否则保持原始名称。",
+                    "type": "string",
+                    "const": "keep-class"
+                }
+            ]
+        },
+        "EmmyrcHover": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "description": "是否启用悬浮提示。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                }
+            }
+        },
+        "EmmyrcInlayHint": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "description": "是否启用内联提示。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                },
+                "enumParamHint": {
+                    "description": "是否启用枚举参数提示。",
+                    "type": "boolean",
+                    "default": false,
+                    "x-vscode-setting": true
+                },
+                "indexHint": {
+                    "description": "在索引表达式跨行时，显示提示。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                },
+                "localHint": {
+                    "description": "是否启用局部变量提示。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                },
+                "metaCallHint": {
+                    "description": "是否启用 `__call` 调用提示。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                },
+                "overrideHint": {
+                    "description": "是否启用重写提示。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                },
+                "paramHint": {
+                    "description": "是否启用参数提示。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                }
+            }
+        },
+        "EmmyrcInlineValues": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "description": "是否启用内联值。用于在调试断点时显示变量值。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                }
+            }
+        },
+        "EmmyrcLuaVersion": {
+            "oneOf": [
+                {
+                    "description": "Lua 5.1",
+                    "type": "string",
+                    "const": "Lua5.1"
+                },
+                {
+                    "description": "LuaJIT",
+                    "type": "string",
+                    "const": "LuaJIT"
+                },
+                {
+                    "description": "Lua 5.2",
+                    "type": "string",
+                    "const": "Lua5.2"
+                },
+                {
+                    "description": "Lua 5.3",
+                    "type": "string",
+                    "const": "Lua5.3"
+                },
+                {
+                    "description": "Lua 5.4",
+                    "type": "string",
+                    "const": "Lua5.4"
+                },
+                {
+                    "description": "Lua 5.5",
+                    "type": "string",
+                    "const": "Lua5.5"
+                },
+                {
+                    "description": "Lua Latest",
+                    "type": "string",
+                    "const": "LuaLatest"
+                }
+            ]
+        },
+        "EmmyrcNonStdSymbol": {
+            "type": "string",
+            "enum": [
+                "//",
+                "/**/",
+                "`",
+                "+=",
+                "-=",
+                "*=",
+                "/=",
+                "%=",
+                "^=",
+                "//=",
+                "|=",
+                "&=",
+                "<<=",
+                ">>=",
+                "||",
+                "&&",
+                "!",
+                "!=",
+                "continue"
+            ]
+        },
+        "EmmyrcReference": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "description": "是否启用引用搜索。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                },
+                "fuzzySearch": {
+                    "description": "是否启用模糊搜索。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                },
+                "shortStringSearch": {
+                    "description": "缓存短字符串用于搜索。",
+                    "type": "boolean",
+                    "default": false,
+                    "x-vscode-setting": true
+                }
+            }
+        },
+        "EmmyrcReformat": {
+            "type": "object",
+            "properties": {
+                "externalTool": {
+                    "description": "Whether to enable internal code reformatting.",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/EmmyrcExternalTool"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "useDiff": {
+                    "description": "Whether to use the diff algorithm for formatting.",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "EmmyrcResource": {
+            "type": "object",
+            "properties": {
+                "paths": {
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "EmmyrcRuntime": {
+            "type": "object",
+            "properties": {
+                "classDefaultCall": {
+                    "description": "类默认重载函数。",
+                    "$ref": "#/$defs/ClassDefaultCall",
+                    "default": {
+                        "forceNonColon": false,
+                        "forceReturnSelf": false,
+                        "functionName": ""
+                    }
+                },
+                "extensions": {
+                    "description": "文件扩展名。例如：.lua, .lua.txt",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "frameworkVersions": {
+                    "description": "框架版本列表。",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "nonstandardSymbol": {
+                    "description": "Non-standard symbols.",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "$ref": "#/$defs/EmmyrcNonStdSymbol"
+                    }
+                },
+                "requireLikeFunction": {
+                    "description": "类似 require 的函数列表。",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "requirePattern": {
+                    "description": "require 模式。例如：\"?.lua\", \"?/init.lua\"",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "version": {
+                    "description": "Lua 版本。",
+                    "$ref": "#/$defs/EmmyrcLuaVersion",
+                    "default": "LuaLatest"
+                }
+            }
+        },
+        "EmmyrcSemanticToken": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "description": "是否启用语义标记。",
+                    "type": "boolean",
+                    "default": true,
+                    "x-vscode-setting": true
+                },
+                "renderDocumentationMarkup": {
+                    "description": "Render Markdown/RST in documentation. Set `doc.syntax` for this option to have effect.",
+                    "type": "boolean",
+                    "default": false,
+                    "x-vscode-setting": true
+                }
+            }
+        },
+        "EmmyrcSignature": {
+            "type": "object",
+            "properties": {
+                "detailSignatureHelper": {
+                    "description": "是否启用签名帮助。",
+                    "type": "boolean",
+                    "default": true
+                }
+            }
+        },
+        "EmmyrcStrict": {
+            "type": "object",
+            "properties": {
+                "arrayIndex": {
+                    "description": "是否启用严格模式数组索引，严格模式下数组取值返回将包含 nil。",
+                    "type": "boolean",
+                    "default": true
+                },
+                "docBaseConstMatchBaseType": {
+                    "description": "doc定义的基础常量类型可以匹配基础类型，使 int 可以匹配 `---@alias id 1|2|3`，string 同理。",
+                    "type": "boolean",
+                    "default": false
+                },
+                "metaOverrideFileDefine": {
+                    "description": "`---@meta`文件的定义完全覆盖真实文件的定义。",
+                    "type": "boolean",
+                    "default": true
+                },
+                "requirePath": {
+                    "description": "是否启用严格模式 require 路径。严格模式时 require 必须从指定的根目录开始。",
+                    "type": "boolean",
+                    "default": false
+                },
+                "typeCall": {
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "EmmyrcWorkspace": {
+            "type": "object",
+            "properties": {
+                "enableReindex": {
+                    "description": "启用重新索引。",
+                    "type": "boolean",
+                    "default": false,
+                    "x-vscode-setting": true
+                },
+                "encoding": {
+                    "description": "编码。例如：\"utf-8\"",
+                    "type": "string",
+                    "default": "utf-8"
+                },
+                "ignoreDir": {
+                    "description": "忽略的目录。",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ignoreGlobs": {
+                    "description": "忽略的文件。例如：[\"**/*.lua\"]",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "library": {
+                    "description": "库路径。例如：\"/usr/local/share/lua/5.1\"",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "moduleMap": {
+                    "description": "模块映射列表。key 是正则表达式，value 是新的模块正则表达式\n 例如：{\n    \"^(.*)$\": \"module_$1\"\n    \"^lib(.*)$\": \"script$1\"\n}",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "$ref": "#/$defs/EmmyrcWorkspaceModuleMap"
+                    }
+                },
+                "preloadFileSize": {
+                    "type": "integer",
+                    "format": "int32",
+                    "default": 0
+                },
+                "reindexDuration": {
+                    "description": "当保存文件时，ls 将在指定毫秒后重新索引工作区。",
+                    "type": "integer",
+                    "format": "uint64",
+                    "default": 5000,
+                    "minimum": 0,
+                    "x-vscode-setting": true
+                },
+                "workspaceRoots": {
+                    "description": "工作区根目录列表。例如：[\"src\", \"test\"]",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "EmmyrcWorkspaceModuleMap": {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string"
+                },
+                "replace": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "pattern",
+                "replace"
+            ]
         }
-      }
-    },
-    "EmmyrcDoc": {
-      "type": "object",
-      "properties": {
-        "knownTags": {
-          "description": "已知文档标签列表。",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        },
-        "privateName": {
-          "description": "将特定字段名视为私有，例如 `m_*` 表示 `XXX.m_id` 和 `XXX.m_type` 是私有字段，只能在定义所在的类中访问。",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "EmmyrcDocumentColor": {
-      "type": "object",
-      "properties": {
-        "enable": {
-          "description": "是否启用文档颜色。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        }
-      }
-    },
-    "EmmyrcFilenameConvention": {
-      "oneOf": [
-        {
-          "description": "保持原始文件名。",
-          "type": "string",
-          "const": "keep"
-        },
-        {
-          "description": "将文件名转换为蛇形(snake_case)命名。",
-          "type": "string",
-          "const": "snake-case"
-        },
-        {
-          "description": "将文件名转换为帕斯卡(PascalCase)命名。",
-          "type": "string",
-          "const": "pascal-case"
-        },
-        {
-          "description": "将文件名转换为驼峰(camelCase)命名。",
-          "type": "string",
-          "const": "camel-case"
-        },
-        {
-          "description": "返回类定义时，使用类名，否则保持原始名称。",
-          "type": "string",
-          "const": "keep-class"
-        }
-      ]
-    },
-    "EmmyrcHover": {
-      "type": "object",
-      "properties": {
-        "enable": {
-          "description": "是否启用悬浮提示。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        }
-      }
-    },
-    "EmmyrcInlayHint": {
-      "type": "object",
-      "properties": {
-        "enable": {
-          "description": "是否启用内联提示。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        },
-        "enumParamHint": {
-          "description": "是否启用枚举参数提示。",
-          "type": "boolean",
-          "default": false,
-          "x-vscode-setting": true
-        },
-        "indexHint": {
-          "description": "在索引表达式跨行时，显示提示。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        },
-        "localHint": {
-          "description": "是否启用局部变量提示。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        },
-        "metaCallHint": {
-          "description": "是否启用 `__call` 调用提示。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        },
-        "overrideHint": {
-          "description": "是否启用重写提示。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        },
-        "paramHint": {
-          "description": "是否启用参数提示。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        }
-      }
-    },
-    "EmmyrcInlineValues": {
-      "type": "object",
-      "properties": {
-        "enable": {
-          "description": "是否启用内联值。用于在调试断点时显示变量值。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        }
-      }
-    },
-    "EmmyrcLuaVersion": {
-      "oneOf": [
-        {
-          "description": "Lua 5.1",
-          "type": "string",
-          "const": "Lua5.1"
-        },
-        {
-          "description": "LuaJIT",
-          "type": "string",
-          "const": "LuaJIT"
-        },
-        {
-          "description": "Lua 5.2",
-          "type": "string",
-          "const": "Lua5.2"
-        },
-        {
-          "description": "Lua 5.3",
-          "type": "string",
-          "const": "Lua5.3"
-        },
-        {
-          "description": "Lua 5.4",
-          "type": "string",
-          "const": "Lua5.4"
-        },
-        {
-          "description": "Lua 5.5",
-          "type": "string",
-          "const": "Lua5.5"
-        },
-        {
-          "description": "Lua Latest",
-          "type": "string",
-          "const": "LuaLatest"
-        }
-      ]
-    },
-    "EmmyrcReference": {
-      "type": "object",
-      "properties": {
-        "enable": {
-          "description": "是否启用引用搜索。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        },
-        "fuzzySearch": {
-          "description": "是否启用模糊搜索。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        },
-        "shortStringSearch": {
-          "description": "缓存短字符串用于搜索。",
-          "type": "boolean",
-          "default": false,
-          "x-vscode-setting": true
-        }
-      }
-    },
-    "EmmyrcResource": {
-      "type": "object",
-      "properties": {
-        "paths": {
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "EmmyrcRuntime": {
-      "type": "object",
-      "properties": {
-        "classDefaultCall": {
-          "description": "类默认重载函数。",
-          "$ref": "#/$defs/ClassDefaultCall",
-          "default": {
-            "forceNonColon": false,
-            "forceReturnSelf": false,
-            "functionName": ""
-          }
-        },
-        "extensions": {
-          "description": "文件扩展名。例如：.lua, .lua.txt",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        },
-        "frameworkVersions": {
-          "description": "框架版本列表。",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        },
-        "requireLikeFunction": {
-          "description": "类似 require 的函数列表。",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        },
-        "requirePattern": {
-          "description": "require 模式。例如：\"?.lua\", \"?/init.lua\"",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        },
-        "version": {
-          "description": "Lua 版本。",
-          "$ref": "#/$defs/EmmyrcLuaVersion",
-          "default": "LuaLatest"
-        }
-      }
-    },
-    "EmmyrcSemanticToken": {
-      "type": "object",
-      "properties": {
-        "enable": {
-          "description": "是否启用语义标记。",
-          "type": "boolean",
-          "default": true,
-          "x-vscode-setting": true
-        }
-      }
-    },
-    "EmmyrcSignature": {
-      "type": "object",
-      "properties": {
-        "detailSignatureHelper": {
-          "description": "是否启用签名帮助。",
-          "type": "boolean",
-          "default": true
-        }
-      }
-    },
-    "EmmyrcStrict": {
-      "type": "object",
-      "properties": {
-        "arrayIndex": {
-          "description": "是否启用严格模式数组索引，严格模式下数组取值返回将包含 nil。",
-          "type": "boolean",
-          "default": true
-        },
-        "docBaseConstMatchBaseType": {
-          "description": "doc定义的基础常量类型可以匹配基础类型，使 int 可以匹配 `---@alias id 1|2|3`，string 同理。",
-          "type": "boolean",
-          "default": false
-        },
-        "metaOverrideFileDefine": {
-          "description": "`---@meta`文件的定义完全覆盖真实文件的定义。",
-          "type": "boolean",
-          "default": true
-        },
-        "requirePath": {
-          "description": "是否启用严格模式 require 路径。严格模式时 require 必须从指定的根目录开始。",
-          "type": "boolean",
-          "default": false
-        },
-        "typeCall": {
-          "type": "boolean",
-          "default": false
-        }
-      }
-    },
-    "EmmyrcWorkspace": {
-      "type": "object",
-      "properties": {
-        "enableReindex": {
-          "description": "启用重新索引。",
-          "type": "boolean",
-          "default": false,
-          "x-vscode-setting": true
-        },
-        "encoding": {
-          "description": "编码。例如：\"utf-8\"",
-          "type": "string",
-          "default": "utf-8"
-        },
-        "ignoreDir": {
-          "description": "忽略的目录。",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        },
-        "ignoreGlobs": {
-          "description": "忽略的文件。例如：[\"**/*.lua\"]",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        },
-        "library": {
-          "description": "库路径。例如：\"/usr/local/share/lua/5.1\"",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        },
-        "moduleMap": {
-          "description": "模块映射列表。key 是正则表达式，value 是新的模块正则表达式\n 例如：{\n    \"^(.*)$\": \"module_$1\"\n    \"^lib(.*)$\": \"script$1\"\n}",
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/EmmyrcWorkspaceModuleMap"
-          }
-        },
-        "preloadFileSize": {
-          "type": "integer",
-          "format": "int32",
-          "default": 0
-        },
-        "reindexDuration": {
-          "description": "当保存文件时，ls 将在指定毫秒后重新索引工作区。",
-          "type": "integer",
-          "format": "uint64",
-          "default": 5000,
-          "minimum": 0,
-          "x-vscode-setting": true
-        },
-        "workspaceRoots": {
-          "description": "工作区根目录列表。例如：[\"src\", \"test\"]",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "EmmyrcWorkspaceModuleMap": {
-      "type": "object",
-      "properties": {
-        "pattern": {
-          "type": "string"
-        },
-        "replace": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "pattern",
-        "replace"
-      ]
     }
-  }
 }


### PR DESCRIPTION
New script can be invoked via

```sh
npm run release -- "0.9.27" "0.11.0"
```

where first argument is new version of extension, and second argument is new version of language server.

The script automatically updates versions in `package.json` and `build/config.json`, downloads new schema from github, and syncs translations and extension settings.