### PR TITLE
Update languageConfiguration.ts

### DIFF
--- a/src/languageConfiguration.ts
+++ b/src/languageConfiguration.ts
@@ -114,6 +114,6 @@ export class LuaLanguageConfiguration implements LanguageConfiguration {
      * Matches strings, numbers, and identifiers
      */
     private buildWordPattern(): RegExp {
-        return /((?<=')[^']+(?='))|((?<=")[^"]+(?="))|(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\s]+)/g;
+        return /((?<=')[^']+(?='))|((?<=")[^"]+(?="))|(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\-\s]+)/g;
     }
 }


### PR DESCRIPTION
Seems `---foo` and `--- foo` is being treated differently. 

For example; Any other extension that adds text after `---` eats the `---` when adding the text, end result being `text` instead of `---text`.

This change fixes that.