### PR TITLE
add configurationAttribute ext for emmylua_attach

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,13 @@
                                 "type": "boolean",
                                 "description": "%debug.attach.captureLog%",
                                 "default": false
+                            },
+                            "ext": {
+                                "type": "array",
+                                "description": "Lua文件后缀",
+                                "default": [
+                                    ".lua"
+                                ]
                             }
                         }
                     }
@@ -184,7 +191,12 @@
                         "name": "%debug.attach.name%",
                         "pid": 0,
                         "processName": "",
-                        "captureLog": false
+                        "captureLog": false,
+                        "ext": [
+                            ".lua",
+                            ".lua.txt",
+                            ".lua.bytes"
+                        ]
                     }
                 ],
                 "configurationSnippets": [

--- a/src/debugger/attach/EmmyAttachDebuggerProvider.ts
+++ b/src/debugger/attach/EmmyAttachDebuggerProvider.ts
@@ -26,7 +26,7 @@ export class EmmyAttachDebuggerProvider extends DebuggerProvider {
         configuration.sourcePaths = this.getSourceRoots();
         configuration.request = "attach";
         configuration.type = "emmylua_attach";
-        configuration.ext = this.getExt();
+        configuration.ext = configuration.ext ?? this.getExt();
         configuration.processName = configuration.processName ?? ""
         if (configuration.pid > 0) {
             return configuration;


### PR DESCRIPTION
为 debugger emmylua_attach 添加 ext 覆盖默认的 this.getExt()。
用户不传此参数还是使用默认的。
不会破坏现有配置